### PR TITLE
vgimg dpi, vgsvg origin, and legend alignment

### DIFF
--- a/legend.go
+++ b/legend.go
@@ -114,6 +114,7 @@ func (l *Legend) draw(c draw.Canvas) {
 		yoffs := (enth - l.TextStyle.Height(e.text)) / 2
 		c.FillText(l.TextStyle, textx, icon.Min.Y+yoffs, xalign, 0, e.text)
 		icon.Min.Y -= enth + l.Padding
+		icon.Max.Y -= enth + l.Padding
 	}
 }
 

--- a/plot.go
+++ b/plot.go
@@ -457,19 +457,19 @@ func (p *Plot) Save(width, height float64, file string) (err error) {
 		c = vgeps.NewTitle(w, h, file)
 
 	case ".jpg", ".jpeg":
-		c = vgimg.JpegCanvas{Canvas: vgimg.New(w, h)}
+		c = vgimg.JpegCanvas{Canvas: vgimg.New(w, h, 96)}
 
 	case ".pdf":
 		c = vgpdf.New(w, h)
 
 	case ".png":
-		c = vgimg.PngCanvas{Canvas: vgimg.New(w, h)}
+		c = vgimg.PngCanvas{Canvas: vgimg.New(w, h, 96)}
 
 	case ".svg":
 		c = vgsvg.New(w, h)
 
 	case ".tiff":
-		c = vgimg.TiffCanvas{Canvas: vgimg.New(w, h)}
+		c = vgimg.TiffCanvas{Canvas: vgimg.New(w, h, 96)}
 
 	default:
 		return fmt.Errorf("Unsupported file extension: %s", ext)

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -183,6 +183,7 @@ func (c *Canvas) FillString(font vg.Font, x, y vg.Length, str string) {
 		registeredFont[font.Name()] = true
 	}
 	c.gc.SetFontData(data)
+	c.gc.SetFontSize(float64(font.Size))
 	c.gc.Translate(x.Dots(c), y.Dots(c))
 	c.gc.Scale(1, -1)
 	c.gc.FillString(str)

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -22,9 +22,6 @@ import (
 	"golang.org/x/image/tiff"
 )
 
-// dpi is the number of dots per inch.
-const dpi = 96
-
 // Canvas implements the vg.Canvas interface,
 // drawing to an image.Image using draw2d.
 type Canvas struct {
@@ -40,41 +37,44 @@ type Canvas struct {
 // New returns a new image canvas with
 // the size specified  rounded up to the
 // nearest pixel.
-func New(width, height vg.Length) *Canvas {
-	w := width / vg.Inch * dpi
-	h := height / vg.Inch * dpi
+// dpi is the number of dots per inch.
+func New(width, height vg.Length, dpi int) *Canvas {
+	w := width / vg.Inch * vg.Length(dpi)
+	h := height / vg.Inch * vg.Length(dpi)
 	img := image.NewRGBA(image.Rect(0, 0, int(w), int(h)))
 
-	return NewImage(img)
+	return NewImage(img, dpi)
 }
 
 // NewImage returns a new image canvas
 // that draws to the given image.  The
 // minimum point of the given image
 // should probably be 0,0.
-func NewImage(img draw.Image) *Canvas {
+// dpi is the number of dots per inch.
+func NewImage(img draw.Image, dpi int) *Canvas {
 	w := float64(img.Bounds().Max.X - img.Bounds().Min.X)
 	h := float64(img.Bounds().Max.Y - img.Bounds().Min.Y)
 	gc := draw2d.NewGraphicContext(img)
 	gc.SetDPI(dpi)
 	gc.Scale(1, -1)
 	gc.Translate(+0.5*w, -0.5*h)
-	return NewImageWithContext(img, gc)
+	return NewImageWithContext(img, gc, dpi)
 }
 
 // NewImageWithContext returns a new image canvas
 // that draws to the given image, using the given graphic context.
 // The minimum point of the given image
 // should probably be 0,0.
-func NewImageWithContext(img draw.Image, gc draw2d.GraphicContext) *Canvas {
+// dpi is the number of dots per inch.
+func NewImageWithContext(img draw.Image, gc draw2d.GraphicContext, dpi int) *Canvas {
 	w := float64(img.Bounds().Max.X - img.Bounds().Min.X)
 	h := float64(img.Bounds().Max.Y - img.Bounds().Min.Y)
 	draw.Draw(img, img.Bounds(), image.White, image.ZP, draw.Src)
 	c := &Canvas{
 		gc:    gc,
 		img:   img,
-		w:     vg.Length(w/dpi) * vg.Inch,
-		h:     vg.Length(h/dpi) * vg.Inch,
+		w:     vg.Length(w/float64(dpi)) * vg.Inch,
+		h:     vg.Length(h/float64(dpi)) * vg.Inch,
 		color: []color.Color{color.Black},
 	}
 	vg.Initialize(c)

--- a/vg/vgsvg/vgsvg.go
+++ b/vg/vgsvg/vgsvg.go
@@ -66,10 +66,10 @@ func New(w, h vg.Length) *Canvas {
 		pr, h/vg.Inch,
 	)
 
-	// Swap the origin to the bottom left.
+	// Swap the origin to the center.
 	// This must be matched with a </g> when saving,
 	// before the closing </svg>.
-	c.svg.Gtransform(fmt.Sprintf("scale(1, -1) translate(0, -%.*g)", pr, h.Dots(c)))
+	c.svg.Gtransform(fmt.Sprintf("scale(1, -1) translate(%.*g, -%.*g)", pr, w.Dots(c)/2, pr, h.Dots(c)/2))
 
 	vg.Initialize(c)
 	return c


### PR DESCRIPTION
Hi,

In these changes I fixed a bug in the alignment between the legend keys and their respective thumbnails, and changed the origin in vgsvg to be the middle of the document so that it is consistent with vgimg. When the origin was at the bottom left corner as before, using the draw.Canvas.Crop() method to create subfigures produced incorrect results.

Also, in vgimg, 96 dpi is not sufficient for certain applications, such as print publication, so making 96 dpi a constant limits the usefulness. Instead, I've made dpi an input argument for creating a new canvas, but if backwards compatibility is desired perhaps there could be separate functions for creating a new canvas, some that require dpi to be specified and others that don't.