### PR TITLE
plot: add WriterTo method to Plot

### DIFF
--- a/vg/draw/canvas.go
+++ b/vg/draw/canvas.go
@@ -217,10 +217,7 @@ func (CrossGlyph) DrawGlyph(c *Canvas, sty GlyphStyle, pt Point) {
 }
 
 // New returns a new (bounded) draw.Canvas.
-func New(c interface {
-	vg.Canvas
-	Size() (vg.Length, vg.Length)
-}) Canvas {
+func New(c vg.CanvasSizer) Canvas {
 	w, h := c.Size()
 	return NewCanvas(c, w, h)
 }

--- a/vg/vg.go
+++ b/vg/vg.go
@@ -79,6 +79,12 @@ type Canvas interface {
 	DPI() float64
 }
 
+// CanvasSizer is a Canvas with a defined size.
+type CanvasSizer interface {
+	Canvas
+	Size() (x, y Length)
+}
+
 // Initialize sets all of the canvas's values to their
 // initial values.
 func Initialize(c Canvas) {


### PR DESCRIPTION
This is a first stab at implementing a generalised plot writing method as suggested [here](https://github.com/gonum/plot/pull/186#discussion_r27268402).

I'm not completely happy with it for a couple of reasons: 1. we lose the title in eps (I'm less concerned about this) and 2. it's not extensible.

Addressing the second point. If we have a map[string]func(w, h vg.Length) interface { vg.CanvasSizer; io.WriterTo } that can be registered to, then this problem goes away. This map must be in vg, and referenced from the WriterTo method. Then each vg implementation that can make a WriterTo will register in an init.