### PR TITLE
vgx11: fix translate offset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ go:
 env:
   global:
    - secure: "GYPf9iqbY/5YLmorhVxH2Q4Y8/kxF3MWxDau8Sb2QnineLAJZA2HKi4aWdZIoK8AMAJgXdHUC4Pw2jywp9nC2Q+TW1+57tp0uLLIdghuwif78oyqykhlt11ny+SUk5PAkqYmm+dCbA0kxShg1hFFfHGTTiDuWklTWomxGGICSPc="
+   - DISPLAY: ":99.0"
 
 before_install:
  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
  - go get github.com/mattn/goveralls
+ - sh -e /etc/init.d/xvfb start
 
 script:
  - go get -d -t -v ./...

--- a/vg/vgimg/vgimg_test.go
+++ b/vg/vgimg/vgimg_test.go
@@ -38,6 +38,8 @@ func TestIssue179(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	defer f.Close()
+
 	want, err := ioutil.ReadAll(f)
 	if err != nil {
 		t.Error(err)

--- a/vg/vgx11/canvas.go
+++ b/vg/vgx11/canvas.go
@@ -4,8 +4,7 @@
 
 // +build !windows
 
-// The vgx11 package uses xgbutil (github.com/BurntSushi/xgbutil)
-// as a X11-display backend for vg.
+// Package vgx11 implements X-Window vg support.
 package vgx11
 
 import (
@@ -69,7 +68,7 @@ func NewImage(img draw.Image, name string) (*Canvas, error) {
 	gc := draw2d.NewGraphicContextWithPainter(ximg, painter)
 	gc.SetDPI(dpi)
 	gc.Scale(1, -1)
-	gc.Translate(+0.5*w, -0.5*h)
+	gc.Translate(0, -h)
 
 	wid := ximg.XShowExtra(name, true)
 	go func() {

--- a/vg/vgx11/canvas_test.go
+++ b/vg/vgx11/canvas_test.go
@@ -1,0 +1,69 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package vgx11
+
+import (
+	"bytes"
+	"image/jpeg"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gonum/plot"
+	"github.com/gonum/plot/plotter"
+	"github.com/gonum/plot/vg"
+	"github.com/gonum/plot/vg/draw"
+)
+
+// hasX11 checks if X11 is available by looking at the DISPLAY environment variable
+func hasX11() bool {
+	return os.Getenv("DISPLAY") != ""
+}
+
+func TestIssue179(t *testing.T) {
+	if !hasX11() {
+		t.Skip("no X11 environment")
+	}
+
+	scatter, err := plotter.NewScatter(plotter.XYs{{1, 1}, {0, 1}, {0, 0}})
+	if err != nil {
+		t.Fatalf("error: %v\n", err)
+	}
+	p, err := plot.New()
+	if err != nil {
+		t.Fatalf("error: %v\n", err)
+	}
+	p.Add(scatter)
+	p.HideAxes()
+
+	c, err := New(5.08*vg.Centimeter, 5.08*vg.Centimeter, "test issue179")
+	if err != nil {
+		t.Fatalf("error: %v\n", err)
+	}
+
+	p.Draw(draw.New(c))
+	b := bytes.NewBuffer([]byte{})
+	err = jpeg.Encode(b, c.ximg, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	f, err := os.Open(filepath.Join("..", "vgimg", "testdata", "issue179.jpg"))
+	if err != nil {
+		t.Error(err)
+	}
+	defer f.Close()
+
+	want, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(b.Bytes(), want) {
+		t.Error("Image mismatch")
+	}
+}


### PR DESCRIPTION
Address issue #179  by translating the image to (0,-h) so (0,0) is at the
bottom-left corner for the X11 backend.

``go test ./...`` will skip the X11 test if ``$DISPLAY`` is not defined.