### PR TITLE
vg: add format registration

### DIFF
--- a/gob/gob_test.go
+++ b/gob/gob_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
 	"github.com/gonum/plot/vg/draw"
+	_ "github.com/gonum/plot/vg/vgimg"
 )
 
 func init() {

--- a/plot.go
+++ b/plot.go
@@ -16,7 +16,6 @@
 package plot
 
 import (
-	"fmt"
 	"image/color"
 	"io"
 	"math"
@@ -26,10 +25,6 @@ import (
 
 	"github.com/gonum/plot/vg"
 	"github.com/gonum/plot/vg/draw"
-	"github.com/gonum/plot/vg/vgeps"
-	"github.com/gonum/plot/vg/vgimg"
-	"github.com/gonum/plot/vg/vgpdf"
-	"github.com/gonum/plot/vg/vgsvg"
 )
 
 var (
@@ -440,49 +435,23 @@ func (p *Plot) NominalY(names ...string) {
 }
 
 // WriterTo returns an io.WriterTo that will write the plot as
-// the specified image format.
-//
-// Supported formats are:
-//
-//  eps, jpg|jpeg, pdf, png, svg, and tif|tiff.
+// the specified image format. Available formats can be queried
+// by calling vg.Formats. Formats may be added by calling
+// vg.Register.
 func (p *Plot) WriterTo(w, h vg.Length, format string) (io.WriterTo, error) {
-	var c interface {
-		vg.CanvasSizer
-		io.WriterTo
-	}
-	switch format {
-	case "eps":
-		c = vgeps.New(w, h)
-
-	case "jpg", "jpeg":
-		c = vgimg.JpegCanvas{Canvas: vgimg.New(w, h)}
-
-	case "pdf":
-		c = vgpdf.New(w, h)
-
-	case "png":
-		c = vgimg.PngCanvas{Canvas: vgimg.New(w, h)}
-
-	case "svg":
-		c = vgsvg.New(w, h)
-
-	case "tif", "tiff":
-		c = vgimg.TiffCanvas{Canvas: vgimg.New(w, h)}
-
-	default:
-		return nil, fmt.Errorf("unsupported format: %q", format)
+	var c vg.CanvasWriterTo
+	c, err := vg.NewCanvasWriterTo(format, w, h)
+	if err != nil {
+		return nil, err
 	}
 	p.Draw(draw.New(c))
 
 	return c, nil
 }
 
-// Save saves the plot to an image file.  The file format is determined
-// by the extension.
-//
-// Supported extensions are:
-//
-//  .eps, .jpg, .jpeg, .pdf, .png, .svg, .tif and .tiff.
+// Save saves the plot to an image file. The file format is determined
+// by the extension. Valid format extensions may be queried by calling
+// vg.Formats.
 func (p *Plot) Save(w, h vg.Length, file string) (err error) {
 	f, err := os.Create(file)
 	if err != nil {

--- a/plotter/main.go
+++ b/plotter/main.go
@@ -21,6 +21,11 @@ import (
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
 	"github.com/gonum/plot/vg/draw"
+
+	_ "github.com/gonum/plot/vg/vgeps"
+	_ "github.com/gonum/plot/vg/vgimg"
+	_ "github.com/gonum/plot/vg/vgpdf"
+	_ "github.com/gonum/plot/vg/vgsvg"
 )
 
 var examples = []struct {

--- a/plotutil/main.go
+++ b/plotutil/main.go
@@ -12,6 +12,11 @@ import (
 	"github.com/gonum/plot"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/plotutil"
+
+	_ "github.com/gonum/plot/vg/vgeps"
+	_ "github.com/gonum/plot/vg/vgimg"
+	_ "github.com/gonum/plot/vg/vgpdf"
+	_ "github.com/gonum/plot/vg/vgsvg"
 )
 
 var examples = []struct {

--- a/vg/vgeps/vgeps.go
+++ b/vg/vgeps/vgeps.go
@@ -18,6 +18,13 @@ import (
 	"github.com/gonum/plot/vg"
 )
 
+// Register image format handler.
+func init() {
+	vg.Register("eps", func(w, h vg.Length) vg.CanvasWriterTo {
+		return New(w, h)
+	})
+}
+
 type Canvas struct {
 	stk  []ctx
 	w, h vg.Length

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -22,6 +22,26 @@ import (
 	"golang.org/x/image/tiff"
 )
 
+// Register image format handlers.
+func init() {
+	newJPEG := func(w, h vg.Length) vg.CanvasWriterTo {
+		return JpegCanvas{Canvas: New(w, h)}
+	}
+	vg.Register("jpg", newJPEG)
+	vg.Register("jpeg", newJPEG)
+
+	newPNG := func(w, h vg.Length) vg.CanvasWriterTo {
+		return PngCanvas{Canvas: New(w, h)}
+	}
+	vg.Register("png", newPNG)
+
+	newTIFF := func(w, h vg.Length) vg.CanvasWriterTo {
+		return TiffCanvas{Canvas: New(w, h)}
+	}
+	vg.Register("tif", newTIFF)
+	vg.Register("tiff", newTIFF)
+}
+
 // dpi is the number of dots per inch.
 const dpi = 96
 

--- a/vg/vgpdf/vgpdf.go
+++ b/vg/vgpdf/vgpdf.go
@@ -17,6 +17,13 @@ import (
 	"github.com/gonum/plot/vg"
 )
 
+// Register image format handler.
+func init() {
+	vg.Register("pdf", func(w, h vg.Length) vg.CanvasWriterTo {
+		return New(w, h)
+	})
+}
+
 // Canvas implements the vg.Canvas interface,
 // drawing to a PDF.
 type Canvas struct {

--- a/vg/vgsvg/vgsvg.go
+++ b/vg/vgsvg/vgsvg.go
@@ -18,6 +18,13 @@ import (
 	"github.com/gonum/plot/vg"
 )
 
+// Register image format handler.
+func init() {
+	vg.Register("svg", func(w, h vg.Length) vg.CanvasWriterTo {
+		return New(w, h)
+	})
+}
+
 const (
 	// inkscape, Chrome, FireFox, and gpicview all seem
 	// to use 90 dots-per-inch.  I can't find anywhere that


### PR DESCRIPTION
This moves away from hard coded format support and allows much easier
extension for canvas types.

Waiting on #192 - not tested until that change is merged.

@eaburns 