### PR TITLE
all: use github.com/llgcode/draw2d

### DIFF
--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package vgimg implements the vg.Canvas interface using
-// draw2d (code.google.com/p/draw2d/draw2d)
+// draw2d (github.com/llgcode/draw2d)
 // as a backend to output raster images.
 package vgimg
 
@@ -17,9 +17,10 @@ import (
 	"image/png"
 	"io"
 
-	"code.google.com/p/draw2d/draw2d"
-	"github.com/gonum/plot/vg"
+	"github.com/llgcode/draw2d"
 	"golang.org/x/image/tiff"
+
+	"github.com/gonum/plot/vg"
 )
 
 // dpi is the number of dots per inch.

--- a/vg/vgx11/canvas.go
+++ b/vg/vgx11/canvas.go
@@ -11,12 +11,13 @@ import (
 	"image"
 	"image/draw"
 
-	"code.google.com/p/draw2d/draw2d"
 	"github.com/BurntSushi/xgbutil"
 	"github.com/BurntSushi/xgbutil/keybind"
 	"github.com/BurntSushi/xgbutil/xevent"
 	"github.com/BurntSushi/xgbutil/xgraphics"
 	"github.com/BurntSushi/xgbutil/xwindow"
+	"github.com/llgcode/draw2d"
+
 	"github.com/gonum/plot/vg"
 	"github.com/gonum/plot/vg/vgimg"
 )


### PR DESCRIPTION
- `code.google.com/p/xyz` will be retired
- migrate to the new home of `draw2d`