### PR TITLE
Fix label rounding for small tick value.

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -361,7 +361,12 @@ func (DefaultTicks) Ticks(min, max float64) (ticks []Tick) {
 	val := math.Floor(min/majorDelta) * majorDelta
 	for val <= max {
 		if val >= min && val <= max {
-			ticks = append(ticks, Tick{Value: val, Label: fmt.Sprintf("%g", float32(val))})
+			round := float32(val)
+			if val < 1 && val > -1 {
+				round = float32(val + 1)
+				round -= 1
+			}
+			ticks = append(ticks, Tick{Value: val, Label: fmt.Sprintf("%g", round)})
 		}
 		if math.Nextafter(val, val+majorDelta) == val {
 			break

--- a/axis_test.go
+++ b/axis_test.go
@@ -1,0 +1,31 @@
+package plot
+
+import "testing"
+
+func TestAxisSmallTick(t *testing.T) {
+	d := DefaultTicks{}
+	for _, test := range []struct {
+		Min, Max float64
+		Labels   []string
+	}{
+		{
+			Min:    -1.9846500878911073,
+			Max:    0.4370974820125605,
+			Labels: []string{"-1.6", "-0.8", "0"},
+		},
+	} {
+		ticks := d.Ticks(test.Min, test.Max)
+		var count int
+		for _, tick := range ticks {
+			if tick.Label != "" {
+				if test.Labels[count] != tick.Label {
+					t.Error("Ticks mismatch: Want", test.Labels[count], ", got", tick.Label)
+				}
+				count++
+			}
+		}
+		if count != len(test.Labels) {
+			t.Errorf("Too many tick labels")
+		}
+	}
+}


### PR DESCRIPTION
There are floating point errors in computing the tick value, which are eliminated by rounding to a float32. If the value is close to zero, this doesn't remove the rounding errors. If abs(value) < 1, add 1, convert to float32, and then subtract one. This fixes cases where there are a lot of digits for the axis label at 0