### PR TITLE
added method for canvas tiles; changed plotter examples to tiles

### DIFF
--- a/plotter/main.go
+++ b/plotter/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"math"
 	"math/rand"
+	"os"
 
 	"github.com/gonum/matrix/mat64"
 
@@ -49,21 +50,53 @@ var examples = []struct {
 }
 
 var formats = []string{
-	".eps",
-	".pdf",
-	".svg",
-	".png",
-	".tiff",
-	".jpg",
+	"eps",
+	"pdf",
+	"svg",
+	"png",
+	"tiff",
+	"jpg",
 }
 
 func main() {
-	for _, ex := range examples {
-		for _, f := range formats {
-			err := ex.p.Save(4*vg.Inch, 4*vg.Inch, ex.name+f)
-			if err != nil {
-				log.Fatalf("failed to save %s%s: %v", ex.name, f, err)
+	const (
+		p     = 1 * vg.Centimeter
+		nrows = 4
+		ncols = 5
+	)
+	for _, f := range formats {
+		c, err := draw.NewFormattedCanvas(10*ncols*vg.Centimeter,
+			10*nrows*vg.Centimeter, f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		dc := draw.New(c)
+		tiles := draw.Tiles{
+			Rows: nrows, Cols: ncols,
+			PadTop: p, PadBottom: p,
+			PadRight: p, PadLeft: p,
+			PadX: p, PadY: p,
+		}
+		ii := 0
+		for j := 0; j < nrows; j++ {
+			for i := 0; i < ncols; i++ {
+				if ii < len(examples) {
+					ex := examples[ii]
+					ex.p.Draw(tiles.At(dc, i, j))
+					if err != nil {
+						log.Fatalf("failed to draw tile for  %s.%s: %v", ex.name, f, err)
+					}
+					ii++
+				}
 			}
+		}
+		w, err := os.Create("examples." + f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = c.WriteTo(w)
+		if err != nil {
+			log.Fatal(err)
 		}
 	}
 }

--- a/vg/draw/draw_test.go
+++ b/vg/draw/draw_test.go
@@ -16,8 +16,8 @@ func TestCrop(t *testing.T) {
 	}
 	r1 := recorder.New(96)
 	c1 := NewCanvas(r1, 6, 3)
-	c11 := c1.Crop(0, 0, -3, 0)
-	c12 := c1.Crop(3, 0, 0, 0)
+	c11 := Crop(c1, 0, -3, 0, 0)
+	c12 := Crop(c1, 3, 0, 0, 0)
 
 	r2 := recorder.New(96)
 	c2 := NewCanvas(r2, 6, 3)
@@ -54,5 +54,60 @@ func TestCrop(t *testing.T) {
 
 	if !reflect.DeepEqual(r1.Actions, r2.Actions) {
 		t.Errorf(str, r1.Actions, r2.Actions)
+	}
+}
+
+func TestTile(t *testing.T) {
+	r := recorder.New(96)
+	c := NewCanvas(r, 13, 7)
+	const (
+		rows = 2
+		cols = 3
+		pad  = 1
+	)
+	tiles := Tiles{
+		Rows: rows, Cols: cols,
+		PadTop: pad, PadBottom: pad,
+		PadRight: pad, PadLeft: pad,
+		PadX: pad, PadY: pad,
+	}
+	rectangles := [][]Rectangle{
+		{
+			Rectangle{
+				Min: Point{1, 4},
+				Max: Point{4, 6},
+			},
+			Rectangle{
+				Min: Point{5, 4},
+				Max: Point{8, 6},
+			},
+			Rectangle{
+				Min: Point{9, 4},
+				Max: Point{12, 6},
+			},
+		},
+		{
+			Rectangle{
+				Min: Point{1, 1},
+				Max: Point{4, 3},
+			},
+			Rectangle{
+				Min: Point{5, 1},
+				Max: Point{8, 3},
+			},
+			Rectangle{
+				Min: Point{9, 1},
+				Max: Point{12, 3},
+			},
+		},
+	}
+	for j := 0; j < rows; j++ {
+		for i := 0; i < cols; i++ {
+			str := "row %d col %d unexpected result: %+v != %+v"
+			tile := tiles.At(c, i, j)
+			if tile.Rectangle != rectangles[j][i] {
+				t.Errorf(str, j, i, tile.Rectangle, rectangles[j][i])
+			}
+		}
 	}
 }

--- a/vg/vg.go
+++ b/vg/vg.go
@@ -9,6 +9,7 @@ package vg
 
 import (
 	"image/color"
+	"io"
 )
 
 // A Canvas is the main drawing interface for 2D vector
@@ -83,6 +84,12 @@ type Canvas interface {
 type CanvasSizer interface {
 	Canvas
 	Size() (x, y Length)
+}
+
+// CanvasWriterTo is a CanvasSizer with a WriteTo method.
+type CanvasWriterTo interface {
+	CanvasSizer
+	io.WriterTo
 }
 
 // Initialize sets all of the canvas's values to their


### PR DESCRIPTION
I've created a method for tiling the canvas to make subfigures, and I have also changed the plotter examples to be put into subfigures instead of a bunch of individual files. PTAL.