### PR TITLE
vg: drop DPI from Canvas

### DIFF
--- a/plot_test.go
+++ b/plot_test.go
@@ -35,8 +35,8 @@ func TestLegendAlignment(t *testing.T) {
 		l.Add(n, b)
 	}
 
-	r := recorder.New(100)
-	c := draw.NewCanvas(r, 100, 100)
+	var r recorder.Canvas
+	c := draw.NewCanvas(&r, 100, 100)
 	l.Draw(draw.Canvas{
 		Canvas: c.Canvas,
 		Rectangle: draw.Rectangle{

--- a/vg/draw/draw_test.go
+++ b/vg/draw/draw_test.go
@@ -14,13 +14,13 @@ func TestCrop(t *testing.T) {
 		Color: color.NRGBA{0, 20, 0, 123},
 		Width: 0.1 * vg.Inch,
 	}
-	r1 := recorder.New(96)
-	c1 := NewCanvas(r1, 6, 3)
+	var r1 recorder.Canvas
+	c1 := NewCanvas(&r1, 6, 3)
 	c11 := Crop(c1, 0, -3, 0, 0)
 	c12 := Crop(c1, 3, 0, 0, 0)
 
-	r2 := recorder.New(96)
-	c2 := NewCanvas(r2, 6, 3)
+	var r2 recorder.Canvas
+	c2 := NewCanvas(&r2, 6, 3)
 	c21 := Canvas{
 		Canvas: c2.Canvas,
 		Rectangle: Rectangle{
@@ -58,8 +58,8 @@ func TestCrop(t *testing.T) {
 }
 
 func TestTile(t *testing.T) {
-	r := recorder.New(96)
-	c := NewCanvas(r, 13, 7)
+	var r recorder.Canvas
+	c := NewCanvas(&r, 13, 7)
 	const (
 		rows = 2
 		cols = 3

--- a/vg/len.go
+++ b/vg/len.go
@@ -20,9 +20,9 @@ const (
 	Millimeter        = Centimeter / 10
 )
 
-// Dots returns the length in dots for the given Canvas.
-func (l Length) Dots(c Canvas) float64 {
-	return float64(l) / Inch.Points() * c.DPI()
+// Dots returns the length in dots for the given resolution.
+func (l Length) Dots(dpi float64) float64 {
+	return float64(l) / Inch.Points() * dpi
 }
 
 // Points returns the length in postscript points.

--- a/vg/recorder/recorder.go
+++ b/vg/recorder/recorder.go
@@ -17,9 +17,6 @@ var _ vg.Canvas = (*Canvas)(nil)
 
 // Canvas implements vg.Canvas operation serialization.
 type Canvas struct {
-	// Resolution holds the canvas resolution in DPI.
-	Resolution float64
-
 	// Actions holds a log of all methods called on
 	// the canvas.
 	Actions []Action
@@ -68,14 +65,6 @@ func (l callerLocation) String() string {
 	}
 	return fmt.Sprintf("%s:%d ", l.file, l.line)
 }
-
-// New returns a new Canvas with the specified resolution.
-func New(dpi float64) *Canvas { return &Canvas{Resolution: dpi} }
-
-// NewFrom returns a new Canvas from an existing vg.Canvas. vg.Canvas methods
-// called on the Canvas will also be passed to the provided backing
-// vg.Canvas. The Resolution field is set to the value returned by c.DPI.
-func NewFrom(c vg.Canvas) *Canvas { return &Canvas{Resolution: c.DPI(), c: c} }
 
 // Reset resets the Canvas to the base state.
 func (c *Canvas) Reset() {
@@ -412,31 +401,6 @@ func (a *FillString) Call() string {
 }
 
 func (a *FillString) callerLocation() *callerLocation {
-	return &a.l
-}
-
-// DPI corresponds to the vg.Canvas.DPI method.
-type DPI struct {
-	l callerLocation
-}
-
-// DPI implements the DPI method of the vg.Canvas interface.
-func (c *Canvas) DPI() float64 {
-	c.append(&DPI{})
-	return c.Resolution
-}
-
-// Call returns the method call that generated the action.
-func (a *DPI) Call() string {
-	return fmt.Sprintf("%sDPI()", a.l)
-}
-
-// ApplyTo applies the action to the given vg.Canvas.
-func (a *DPI) ApplyTo(c vg.Canvas) {
-	c.DPI()
-}
-
-func (a *DPI) callerLocation() *callerLocation {
 	return &a.l
 }
 

--- a/vg/recorder/recorder_test.go
+++ b/vg/recorder/recorder_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRecorder(t *testing.T) {
-	rec := New(72)
+	var rec Canvas
 	rec.Actions = append(rec.Actions, &FillString{Font: "Times-Roman", Size: 12, X: 0, Y: 10, String: "Text"})
 	rec.Comment("End of preamble")
 	rec.Scale(1, 2)
@@ -24,7 +24,6 @@ func TestRecorder(t *testing.T) {
 	rec.Pop()
 	rec.Translate(3, 4)
 	rec.KeepCaller = false
-	rec.DPI()
 	rec.SetLineWidth(100)
 	rec.SetLineDash([]vg.Length{2, 5}, 6)
 	rec.SetColor(color.RGBA{R: 0x65, G: 0x23, B: 0xf2})
@@ -68,7 +67,6 @@ var want = []string{
 	`github.com/gonum/plot/vg/recorder/recorder_test.go:23 Push()`,
 	`github.com/gonum/plot/vg/recorder/recorder_test.go:24 Pop()`,
 	`github.com/gonum/plot/vg/recorder/recorder_test.go:25 Translate(3, 4)`,
-	`DPI()`,
 	`SetLineWidth(100)`,
 	`SetLineDash([]vg.Length{2, 5}, 6)`,
 	`SetColor(color.RGBA{R:0x65, G:0x23, B:0xf2, A:0x0})`,

--- a/vg/vg.go
+++ b/vg/vg.go
@@ -74,10 +74,6 @@ type Canvas interface {
 	// FillString fills in text at the specified
 	// location using the given font.
 	FillString(f Font, x, y Length, text string)
-
-	// DPI returns the number of canvas dots in
-	// an inch.
-	DPI() float64
 }
 
 // CanvasSizer is a Canvas with a defined size.

--- a/vg/vgeps/vgeps.go
+++ b/vg/vgeps/vgeps.go
@@ -53,8 +53,8 @@ func NewTitle(w, h vg.Length, title string) *Canvas {
 	c.buf.WriteString("%%Creator github.com/gonum/plot/vg/vgeps\n")
 	c.buf.WriteString("%%Title: " + title + "\n")
 	c.buf.WriteString(fmt.Sprintf("%%%%BoundingBox: 0 0 %.*g %.*g\n",
-		pr, w.Dots(c),
-		pr, h.Dots(c)))
+		pr, w.Dots(c.DPI()),
+		pr, h.Dots(c.DPI())))
 	c.buf.WriteString(fmt.Sprintf("%%%%CreationDate: %s\n", time.Now()))
 	c.buf.WriteString("%%Orientation: Portrait\n")
 	c.buf.WriteString("%%EndComments\n")
@@ -75,7 +75,7 @@ func (e *Canvas) cur() *ctx {
 func (e *Canvas) SetLineWidth(w vg.Length) {
 	if e.cur().width != w {
 		e.cur().width = w
-		fmt.Fprintf(e.buf, "%.*g setlinewidth\n", pr, w.Dots(e))
+		fmt.Fprintf(e.buf, "%.*g setlinewidth\n", pr, w.Dots(e.DPI()))
 	}
 }
 
@@ -92,10 +92,10 @@ func (e *Canvas) SetLineDash(dashes []vg.Length, o vg.Length) {
 		e.cur().offs = o
 		e.buf.WriteString("[")
 		for _, d := range dashes {
-			fmt.Fprintf(e.buf, " %.*g", pr, d.Dots(e))
+			fmt.Fprintf(e.buf, " %.*g", pr, d.Dots(e.DPI()))
 		}
 		e.buf.WriteString(" ] ")
-		fmt.Fprintf(e.buf, "%.*g setdash\n", pr, o.Dots(e))
+		fmt.Fprintf(e.buf, "%.*g setdash\n", pr, o.Dots(e.DPI()))
 	}
 }
 
@@ -118,7 +118,7 @@ func (e *Canvas) Rotate(r float64) {
 
 func (e *Canvas) Translate(x, y vg.Length) {
 	fmt.Fprintf(e.buf, "%.*g %.*g translate\n",
-		pr, x.Dots(e), pr, y.Dots(e))
+		pr, x.Dots(e.DPI()), pr, y.Dots(e.DPI()))
 }
 
 func (e *Canvas) Scale(x, y float64) {
@@ -180,7 +180,7 @@ func (e *Canvas) FillString(fnt vg.Font, x, y vg.Length, str string) {
 		fmt.Fprintf(e.buf, "/%s findfont %.*g scalefont setfont\n",
 			fnt.Name(), pr, fnt.Size)
 	}
-	fmt.Fprintf(e.buf, "%.*g %.*g moveto\n", pr, x.Dots(e), pr, y.Dots(e))
+	fmt.Fprintf(e.buf, "%.*g %.*g moveto\n", pr, x.Dots(e.DPI()), pr, y.Dots(e.DPI()))
 	fmt.Fprintf(e.buf, "(%s) show\n", str)
 }
 

--- a/vg/vgeps/vgeps.go
+++ b/vg/vgeps/vgeps.go
@@ -18,6 +18,9 @@ import (
 	"github.com/gonum/plot/vg"
 )
 
+// DPI is the nominal resolution of drawing in EPS.
+const DPI = 72
+
 type Canvas struct {
 	stk  []ctx
 	w, h vg.Length
@@ -53,8 +56,8 @@ func NewTitle(w, h vg.Length, title string) *Canvas {
 	c.buf.WriteString("%%Creator github.com/gonum/plot/vg/vgeps\n")
 	c.buf.WriteString("%%Title: " + title + "\n")
 	c.buf.WriteString(fmt.Sprintf("%%%%BoundingBox: 0 0 %.*g %.*g\n",
-		pr, w.Dots(c.DPI()),
-		pr, h.Dots(c.DPI())))
+		pr, w.Dots(DPI),
+		pr, h.Dots(DPI)))
 	c.buf.WriteString(fmt.Sprintf("%%%%CreationDate: %s\n", time.Now()))
 	c.buf.WriteString("%%Orientation: Portrait\n")
 	c.buf.WriteString("%%EndComments\n")
@@ -75,7 +78,7 @@ func (e *Canvas) cur() *ctx {
 func (e *Canvas) SetLineWidth(w vg.Length) {
 	if e.cur().width != w {
 		e.cur().width = w
-		fmt.Fprintf(e.buf, "%.*g setlinewidth\n", pr, w.Dots(e.DPI()))
+		fmt.Fprintf(e.buf, "%.*g setlinewidth\n", pr, w.Dots(DPI))
 	}
 }
 
@@ -92,10 +95,10 @@ func (e *Canvas) SetLineDash(dashes []vg.Length, o vg.Length) {
 		e.cur().offs = o
 		e.buf.WriteString("[")
 		for _, d := range dashes {
-			fmt.Fprintf(e.buf, " %.*g", pr, d.Dots(e.DPI()))
+			fmt.Fprintf(e.buf, " %.*g", pr, d.Dots(DPI))
 		}
 		e.buf.WriteString(" ] ")
-		fmt.Fprintf(e.buf, "%.*g setdash\n", pr, o.Dots(e.DPI()))
+		fmt.Fprintf(e.buf, "%.*g setdash\n", pr, o.Dots(DPI))
 	}
 }
 
@@ -118,7 +121,7 @@ func (e *Canvas) Rotate(r float64) {
 
 func (e *Canvas) Translate(x, y vg.Length) {
 	fmt.Fprintf(e.buf, "%.*g %.*g translate\n",
-		pr, x.Dots(e.DPI()), pr, y.Dots(e.DPI()))
+		pr, x.Dots(DPI), pr, y.Dots(DPI))
 }
 
 func (e *Canvas) Scale(x, y float64) {
@@ -180,12 +183,8 @@ func (e *Canvas) FillString(fnt vg.Font, x, y vg.Length, str string) {
 		fmt.Fprintf(e.buf, "/%s findfont %.*g scalefont setfont\n",
 			fnt.Name(), pr, fnt.Size)
 	}
-	fmt.Fprintf(e.buf, "%.*g %.*g moveto\n", pr, x.Dots(e.DPI()), pr, y.Dots(e.DPI()))
+	fmt.Fprintf(e.buf, "%.*g %.*g moveto\n", pr, x.Dots(DPI), pr, y.Dots(DPI))
 	fmt.Fprintf(e.buf, "(%s) show\n", str)
-}
-
-func (e *Canvas) DPI() float64 {
-	return 72
 }
 
 // WriteTo writes the canvas to an io.Writer.

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -169,15 +169,15 @@ func (c *Canvas) Size() (w, h vg.Length) {
 
 func (c *Canvas) SetLineWidth(w vg.Length) {
 	c.width = w
-	c.gc.SetLineWidth(w.Dots(c))
+	c.gc.SetLineWidth(w.Dots(c.DPI()))
 }
 
 func (c *Canvas) SetLineDash(ds []vg.Length, offs vg.Length) {
 	dashes := make([]float64, len(ds))
 	for i, d := range ds {
-		dashes[i] = d.Dots(c)
+		dashes[i] = d.Dots(c.DPI())
 	}
-	c.gc.SetLineDash(dashes, offs.Dots(c))
+	c.gc.SetLineDash(dashes, offs.Dots(c.DPI()))
 }
 
 func (c *Canvas) SetColor(clr color.Color) {
@@ -194,7 +194,7 @@ func (c *Canvas) Rotate(t float64) {
 }
 
 func (c *Canvas) Translate(x, y vg.Length) {
-	c.gc.Translate(x.Dots(c), y.Dots(c))
+	c.gc.Translate(x.Dots(c.DPI()), y.Dots(c.DPI()))
 }
 
 func (c *Canvas) Scale(x, y float64) {
@@ -229,14 +229,14 @@ func (c *Canvas) outline(p vg.Path) {
 	for _, comp := range p {
 		switch comp.Type {
 		case vg.MoveComp:
-			c.gc.MoveTo(comp.X.Dots(c), comp.Y.Dots(c))
+			c.gc.MoveTo(comp.X.Dots(c.DPI()), comp.Y.Dots(c.DPI()))
 
 		case vg.LineComp:
-			c.gc.LineTo(comp.X.Dots(c), comp.Y.Dots(c))
+			c.gc.LineTo(comp.X.Dots(c.DPI()), comp.Y.Dots(c.DPI()))
 
 		case vg.ArcComp:
-			c.gc.ArcTo(comp.X.Dots(c), comp.Y.Dots(c),
-				comp.Radius.Dots(c), comp.Radius.Dots(c),
+			c.gc.ArcTo(comp.X.Dots(c.DPI()), comp.Y.Dots(c.DPI()),
+				comp.Radius.Dots(c.DPI()), comp.Radius.Dots(c.DPI()),
 				comp.Start, comp.Angle)
 
 		case vg.CloseComp:
@@ -266,7 +266,7 @@ func (c *Canvas) FillString(font vg.Font, x, y vg.Length, str string) {
 	}
 	c.gc.SetFontData(data)
 	c.gc.SetFontSize(font.Size.Points())
-	c.gc.Translate(x.Dots(c), y.Dots(c))
+	c.gc.Translate(x.Dots(c.DPI()), y.Dots(c.DPI()))
 	c.gc.Scale(1, -1)
 	c.gc.FillString(str)
 }

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -41,7 +41,8 @@ type Canvas struct {
 }
 
 const (
-	// DefaultDPI is the default number of dots per inch.
+	// DefaultDPI is the default dot resolution for image
+	// drawing in dots per inch.
 	DefaultDPI = 96
 
 	// DefaultWidth and DefaultHeight are the default canvas

--- a/vg/vgpdf/vgpdf.go
+++ b/vg/vgpdf/vgpdf.go
@@ -99,10 +99,6 @@ func (c *Canvas) FillString(fnt vg.Font, x, y vg.Length, str string) {
 	c.page.DrawText(t)
 }
 
-func (*Canvas) DPI() float64 {
-	return float64(pdf.Inch)
-}
-
 // pdfPath returns a pdf.Path from a vg.Path.
 func pdfPath(c *Canvas, path vg.Path) *pdf.Path {
 	p := new(pdf.Path)

--- a/vg/vgpdf/vgpdf.go
+++ b/vg/vgpdf/vgpdf.go
@@ -17,6 +17,9 @@ import (
 	"github.com/gonum/plot/vg"
 )
 
+// DPI is the nominal resolution of drawing in PDF.
+const DPI = 72
+
 // Canvas implements the vg.Canvas interface,
 // drawing to a PDF.
 type Canvas struct {

--- a/vg/vgsvg/vgsvg.go
+++ b/vg/vgsvg/vgsvg.go
@@ -69,7 +69,7 @@ func New(w, h vg.Length) *Canvas {
 	// Swap the origin to the bottom left.
 	// This must be matched with a </g> when saving,
 	// before the closing </svg>.
-	c.svg.Gtransform(fmt.Sprintf("scale(1, -1) translate(0, -%.*g)", pr, h.Dots(c)))
+	c.svg.Gtransform(fmt.Sprintf("scale(1, -1) translate(0, -%.*g)", pr, h.Dots(c.DPI())))
 
 	vg.Initialize(c)
 	return c
@@ -103,7 +103,7 @@ func (c *Canvas) Rotate(rot float64) {
 }
 
 func (c *Canvas) Translate(x, y vg.Length) {
-	c.svg.Gtransform(fmt.Sprintf("translate(%.*g, %.*g)", pr, x.Dots(c), pr, y.Dots(c)))
+	c.svg.Gtransform(fmt.Sprintf("translate(%.*g, %.*g)", pr, x.Dots(c.DPI()), pr, y.Dots(c.DPI())))
 	c.cur().gEnds++
 }
 
@@ -126,16 +126,16 @@ func (c *Canvas) Pop() {
 }
 
 func (c *Canvas) Stroke(path vg.Path) {
-	if c.cur().lineWidth.Dots(c) <= 0 {
+	if c.cur().lineWidth.Dots(c.DPI()) <= 0 {
 		return
 	}
 	c.svg.Path(c.pathData(path),
 		style(elm("fill", "#000000", "none"),
 			elm("stroke", "none", colorString(c.cur().color)),
 			elm("stroke-opacity", "1", opacityString(c.cur().color)),
-			elm("stroke-width", "1", "%.*g", pr, c.cur().lineWidth.Dots(c)),
+			elm("stroke-width", "1", "%.*g", pr, c.cur().lineWidth.Dots(c.DPI())),
 			elm("stroke-dasharray", "none", dashArrayString(c)),
-			elm("stroke-dashoffset", "0", "%.*g", pr, c.cur().dashOffset.Dots(c))))
+			elm("stroke-dashoffset", "0", "%.*g", pr, c.cur().dashOffset.Dots(c.DPI()))))
 }
 
 func (c *Canvas) Fill(path vg.Path) {
@@ -150,17 +150,17 @@ func (c *Canvas) pathData(path vg.Path) string {
 	for _, comp := range path {
 		switch comp.Type {
 		case vg.MoveComp:
-			fmt.Fprintf(buf, "M%.*g,%.*g", pr, comp.X.Dots(c), pr, comp.Y.Dots(c))
-			x = comp.X.Dots(c)
-			y = comp.Y.Dots(c)
+			fmt.Fprintf(buf, "M%.*g,%.*g", pr, comp.X.Dots(c.DPI()), pr, comp.Y.Dots(c.DPI()))
+			x = comp.X.Dots(c.DPI())
+			y = comp.Y.Dots(c.DPI())
 		case vg.LineComp:
-			fmt.Fprintf(buf, "L%.*g,%.*g", pr, comp.X.Dots(c), pr, comp.Y.Dots(c))
-			x = comp.X.Dots(c)
-			y = comp.Y.Dots(c)
+			fmt.Fprintf(buf, "L%.*g,%.*g", pr, comp.X.Dots(c.DPI()), pr, comp.Y.Dots(c.DPI()))
+			x = comp.X.Dots(c.DPI())
+			y = comp.Y.Dots(c.DPI())
 		case vg.ArcComp:
-			r := comp.Radius.Dots(c)
-			x0 := comp.X.Dots(c) + r*math.Cos(comp.Start)
-			y0 := comp.Y.Dots(c) + r*math.Sin(comp.Start)
+			r := comp.Radius.Dots(c.DPI())
+			x0 := comp.X.Dots(c.DPI()) + r*math.Cos(comp.Start)
+			y0 := comp.Y.Dots(c.DPI()) + r*math.Sin(comp.Start)
 			if x0 != x || y0 != y {
 				fmt.Fprintf(buf, "L%.*g,%.*g", pr, x0, pr, y0)
 			}
@@ -192,11 +192,11 @@ func circle(w io.Writer, c *Canvas, comp *vg.PathComp) (x, y float64) {
 		panic("Impossible angle")
 	}
 
-	r := comp.Radius.Dots(c)
-	x0 := comp.X.Dots(c) + r*math.Cos(comp.Start+angle/2)
-	y0 := comp.Y.Dots(c) + r*math.Sin(comp.Start+angle/2)
-	x = comp.X.Dots(c) + r*math.Cos(comp.Start+angle)
-	y = comp.Y.Dots(c) + r*math.Sin(comp.Start+angle)
+	r := comp.Radius.Dots(c.DPI())
+	x0 := comp.X.Dots(c.DPI()) + r*math.Cos(comp.Start+angle/2)
+	y0 := comp.Y.Dots(c.DPI()) + r*math.Sin(comp.Start+angle/2)
+	x = comp.X.Dots(c.DPI()) + r*math.Cos(comp.Start+angle)
+	y = comp.Y.Dots(c.DPI()) + r*math.Sin(comp.Start+angle)
 
 	fmt.Fprintf(w, "A%.*g,%.*g 0 %d %d %.*g,%.*g", pr, r, pr, r,
 		large(angle/2), sweep(angle/2), pr, x0, pr, y0) //
@@ -218,9 +218,9 @@ func remainder(x, y float64) float64 {
 // less than a full circle, if it is greater then
 // circle should be used instead.
 func arc(w io.Writer, c *Canvas, comp *vg.PathComp) (x, y float64) {
-	r := comp.Radius.Dots(c)
-	x = comp.X.Dots(c) + r*math.Cos(comp.Start+comp.Angle)
-	y = comp.Y.Dots(c) + r*math.Sin(comp.Start+comp.Angle)
+	r := comp.Radius.Dots(c.DPI())
+	x = comp.X.Dots(c.DPI()) + r*math.Cos(comp.Start+comp.Angle)
+	y = comp.Y.Dots(c.DPI()) + r*math.Sin(comp.Start+comp.Angle)
 	fmt.Fprintf(w, "A%.*g,%.*g 0 %d %d %.*g,%.*g", pr, r, pr, r,
 		large(comp.Angle), sweep(comp.Angle), pr, x, pr, y)
 	return
@@ -256,7 +256,7 @@ func (c *Canvas) FillString(font vg.Font, x, y vg.Length, str string) {
 		sty = "\n\t" + sty
 	}
 	fmt.Fprintf(c.buf, `<text x="%.*g" y="%.*g" transform="scale(1, -1)"%s>%s</text>`+"\n",
-		pr, x.Dots(c), pr, -y.Dots(c), sty, str)
+		pr, x.Dots(c.DPI()), pr, -y.Dots(c.DPI()), sty, str)
 }
 
 var (
@@ -357,7 +357,7 @@ func elm(key, def, f string, vls ...interface{}) string {
 func dashArrayString(c *Canvas) string {
 	str := ""
 	for i, d := range c.cur().dashArray {
-		str += fmt.Sprintf("%.*g", pr, d.Dots(c))
+		str += fmt.Sprintf("%.*g", pr, d.Dots(c.DPI()))
 		if i < len(c.cur().dashArray)-1 {
 			str += ","
 		}


### PR DESCRIPTION
The DPI value is only ever used internally by types to determine the number of dots for a given Length, the alternative is to give the Dots method the DPI value rather than the Canvas.

The DPI method is retained on types that need to know their resolution, although this could be made unexported.

@eaburns This is exploratory, so I'm not fussed if you reject it, but it does drop one method from the vg.Canvas set and it doesn't really look like it impacts in a negative way to my mind. Please take a look.