### PR TITLE
Move functions requiring wide dependencies to their own files.

### DIFF
--- a/vg/draw/canvas.go
+++ b/vg/draw/canvas.go
@@ -5,16 +5,11 @@
 package draw
 
 import (
-	"fmt"
 	"image/color"
 	"math"
 	"strings"
 
 	"github.com/gonum/plot/vg"
-	"github.com/gonum/plot/vg/vgeps"
-	"github.com/gonum/plot/vg/vgimg"
-	"github.com/gonum/plot/vg/vgpdf"
-	"github.com/gonum/plot/vg/vgsvg"
 )
 
 // A Canvas is a vector graphics canvas along with
@@ -225,39 +220,6 @@ func (CrossGlyph) DrawGlyph(c *Canvas, sty GlyphStyle, pt Point) {
 func New(c vg.CanvasSizer) Canvas {
 	w, h := c.Size()
 	return NewCanvas(c, w, h)
-}
-
-// NewFormattedCanvas creates a new vg.CanvasWriterTo with the specified
-// image format.
-//
-// Supported formats are:
-//
-//  eps, jpg|jpeg, pdf, png, svg, and tif|tiff.
-func NewFormattedCanvas(w, h vg.Length, format string) (vg.CanvasWriterTo, error) {
-	var c vg.CanvasWriterTo
-	switch format {
-	case "eps":
-		c = vgeps.New(w, h)
-
-	case "jpg", "jpeg":
-		c = vgimg.JpegCanvas{Canvas: vgimg.New(w, h)}
-
-	case "pdf":
-		c = vgpdf.New(w, h)
-
-	case "png":
-		c = vgimg.PngCanvas{Canvas: vgimg.New(w, h)}
-
-	case "svg":
-		c = vgsvg.New(w, h)
-
-	case "tif", "tiff":
-		c = vgimg.TiffCanvas{Canvas: vgimg.New(w, h)}
-
-	default:
-		return nil, fmt.Errorf("unsupported format: %q", format)
-	}
-	return c, nil
 }
 
 // NewCanvas returns a new (bounded) draw.Canvas of the given size.

--- a/vg/draw/formattedcanvas.go
+++ b/vg/draw/formattedcanvas.go
@@ -1,0 +1,48 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package draw
+
+import (
+	"fmt"
+
+	"github.com/gonum/plot/vg"
+	"github.com/gonum/plot/vg/vgeps"
+	"github.com/gonum/plot/vg/vgimg"
+	"github.com/gonum/plot/vg/vgpdf"
+	"github.com/gonum/plot/vg/vgsvg"
+)
+
+// NewFormattedCanvas creates a new vg.CanvasWriterTo with the specified
+// image format.
+//
+// Supported formats are:
+//
+//  eps, jpg|jpeg, pdf, png, svg, and tif|tiff.
+func NewFormattedCanvas(w, h vg.Length, format string) (vg.CanvasWriterTo, error) {
+	var c vg.CanvasWriterTo
+	switch format {
+	case "eps":
+		c = vgeps.New(w, h)
+
+	case "jpg", "jpeg":
+		c = vgimg.JpegCanvas{Canvas: vgimg.New(w, h)}
+
+	case "pdf":
+		c = vgpdf.New(w, h)
+
+	case "png":
+		c = vgimg.PngCanvas{Canvas: vgimg.New(w, h)}
+
+	case "svg":
+		c = vgsvg.New(w, h)
+
+	case "tif", "tiff":
+		c = vgimg.TiffCanvas{Canvas: vgimg.New(w, h)}
+
+	default:
+		return nil, fmt.Errorf("unsupported format: %q", format)
+	}
+	return c, nil
+}

--- a/vg/vgimg/tiff.go
+++ b/vg/vgimg/tiff.go
@@ -1,0 +1,29 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vgimg
+
+import (
+	"bufio"
+	"io"
+
+	"golang.org/x/image/tiff"
+)
+
+// A TiffCanvas is an image canvas with a WriteTo method that
+// writes a tiff image.
+type TiffCanvas struct {
+	*Canvas
+}
+
+// WriteTo implements the io.WriterTo interface, writing a tiff image.
+func (c TiffCanvas) WriteTo(w io.Writer) (int64, error) {
+	wc := writerCounter{Writer: w}
+	b := bufio.NewWriter(&wc)
+	if err := tiff.Encode(b, c.img, nil); err != nil {
+		return wc.n, err
+	}
+	err := b.Flush()
+	return wc.n, err
+}

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -17,8 +17,6 @@ import (
 	"image/png"
 	"io"
 
-	"golang.org/x/image/tiff"
-
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dimg"
 
@@ -386,23 +384,6 @@ func (c PngCanvas) WriteTo(w io.Writer) (int64, error) {
 	wc := writerCounter{Writer: w}
 	b := bufio.NewWriter(&wc)
 	if err := png.Encode(b, c.img); err != nil {
-		return wc.n, err
-	}
-	err := b.Flush()
-	return wc.n, err
-}
-
-// A TiffCanvas is an image canvas with a WriteTo method that
-// writes a tiff image.
-type TiffCanvas struct {
-	*Canvas
-}
-
-// WriteTo implements the io.WriterTo interface, writing a tiff image.
-func (c TiffCanvas) WriteTo(w io.Writer) (int64, error) {
-	wc := writerCounter{Writer: w}
-	b := bufio.NewWriter(&wc)
-	if err := tiff.Encode(b, c.img, nil); err != nil {
 		return wc.n, err
 	}
 	err := b.Flush()


### PR DESCRIPTION
This makes it easier to use gonum/plot without having to install
all of the dependencies if one does not care about them. For example,
if tiff, pdf, eps and x11 output are not required, it is easy to delete
the vg/vgimg/tiff.go file, vg/draw/formattedcanvas.go (depends on all
the formats known to plot), and the directories vg/vgpdf, vg/vgeps and
vg/vgx11.

I left pdf and jpg in vg/vgimg/vgimg.go, since they do not require a
third party library.