### PR TITLE
vg: provide ParseLength to create a vg.Length from a string

### DIFF
--- a/vg/len.go
+++ b/vg/len.go
@@ -4,6 +4,11 @@
 
 package vg
 
+import (
+	"strconv"
+	"strings"
+)
+
 // A Length is a unit-independent representation of length.
 // Internally, the length is stored in postscript points.
 type Length float64
@@ -28,4 +33,36 @@ func (l Length) Dots(dpi float64) float64 {
 // Points returns the length in postscript points.
 func (l Length) Points() float64 {
 	return float64(l)
+}
+
+// ParseLength parses a Length string.
+// A Length string is a possible signed floating number with a unit.
+// e.g. "42cm" "2.4in" "66pt"
+// If no unit was given, ParseLength assumes it was (postscript) points.
+// Currently valid units are:
+//   mm (millimeter)
+//   cm (centimeter)
+//   in (inch)
+//   pt (point)
+func ParseLength(value string) (Length, error) {
+	var unit Length = 1
+	switch {
+	case strings.HasSuffix(value, "in"):
+		value = value[:len(value)-len("in")]
+		unit = Inch
+	case strings.HasSuffix(value, "cm"):
+		value = value[:len(value)-len("cm")]
+		unit = Centimeter
+	case strings.HasSuffix(value, "mm"):
+		value = value[:len(value)-len("mm")]
+		unit = Millimeter
+	case strings.HasSuffix(value, "pt"):
+		value = value[:len(value)-len("pt")]
+		unit = 1
+	}
+	v, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+	return Length(v) * unit, nil
 }

--- a/vg/vg_test.go
+++ b/vg/vg_test.go
@@ -97,3 +97,68 @@ func lines(w vg.Length) (*plot.Plot, error) {
 
 	return p, nil
 }
+
+func TestParseLength(t *testing.T) {
+	for _, table := range []struct {
+		str  string
+		want vg.Length
+		err  error
+	}{
+		{
+			str:  "42.2cm",
+			want: 42.2 * vg.Centimeter,
+		},
+		{
+			str:  "42.2mm",
+			want: 42.2 * vg.Millimeter,
+		},
+		{
+			str:  "42.2in",
+			want: 42.2 * vg.Inch,
+		},
+		{
+			str:  "42.2pt",
+			want: 42.2,
+		},
+		{
+			str:  "42.2",
+			want: 42.2,
+		},
+		{
+			str: "999bottles",
+			err: fmt.Errorf(`strconv.ParseFloat: parsing "999bottles": invalid syntax`),
+		},
+		{
+			str:  "42inch",
+			want: 42 * vg.Inch,
+			err:  fmt.Errorf(`strconv.ParseFloat: parsing "42inch": invalid syntax`),
+		},
+	} {
+		v, err := vg.ParseLength(table.str)
+		if table.err != nil {
+			if err == nil {
+				t.Errorf("%s: expected an error (%v)\n",
+					table.str, table.err,
+				)
+			}
+			if table.err.Error() != err.Error() {
+				t.Errorf("%s: got error=%q. want=%q\n",
+					table.str, err.Error(), table.err.Error(),
+				)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("error setting flag.Value %q: %v\n",
+				table.str,
+				err,
+			)
+		}
+		if v != table.want {
+			t.Errorf("%s: incorrect value. got %v, want %v\n",
+				table.str,
+				float64(v), float64(table.want),
+			)
+		}
+	}
+}


### PR DESCRIPTION
Making vg.Length implement flag.Value allows for nicer CLI, such
as:
 $ my-cmd -plot-x-size=20cm -plot-y-size=15cm