### PR TITLE
plotutil: add GoldenRatio

### DIFF
--- a/plotutil/goldenratio.go
+++ b/plotutil/goldenratio.go
@@ -1,0 +1,25 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package plotutil
+
+import (
+	"math"
+
+	"github.com/gonum/plot/vg"
+)
+
+// phi is the golden ratio, as defined by:
+//  https://en.wikipedia.org/wiki/Golden_ratio
+var phi = vg.Length(1+math.Sqrt(5)) / 2
+
+// GoldenRatio returns the width and the height such as:
+//  width = size
+//  height = size/phi
+// so that width and height follow the golden proportions.
+func GoldenRatio(size vg.Length) (vg.Length, vg.Length) {
+	w := size
+	h := size / phi
+	return w, h
+}

--- a/plotutil/goldenratio_test.go
+++ b/plotutil/goldenratio_test.go
@@ -1,0 +1,23 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package plotutil
+
+import (
+	"testing"
+
+	"github.com/gonum/plot/vg"
+)
+
+func TestGoldenRatio(t *testing.T) {
+	sz := 10 * vg.Centimeter
+	w, h := GoldenRatio(sz)
+	o := w/h*w/h - w/h - 1
+	if o != 0 {
+		t.Fatalf(
+			"w and h do not follow the golden proportions. got=%v want=0.\n",
+			o,
+		)
+	}
+}


### PR DESCRIPTION
This CL adds a simple functionality to create plots following the
Golden proportions.

Typical use would look like:

```go
  w, h := plotutil.GoldenRatio(10*vg.Centimeter)
  err := p.Save(w, h, "foo.png")
```