### PR TITLE
add support for setting DefaultFont to font file

### DIFF
--- a/vg/font.go
+++ b/vg/font.go
@@ -15,7 +15,9 @@ import (
 	"go/build"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"sync"
 
 	"golang.org/x/image/math/fixed"
@@ -194,7 +196,10 @@ func getFont(name string) (*truetype.Font, error) {
 
 	path, err := fontPath(name)
 	if err != nil {
-		return nil, err
+		path, err = absFontPath(name)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	file, err := os.Open(path)
@@ -218,6 +223,35 @@ func getFont(name string) (*truetype.Font, error) {
 	}
 
 	return font, err
+}
+
+func absFontPath(fontpath string) (string, error) {
+	ext := filepath.Ext(fontpath)
+	if ext == "" {
+		fontpath += ".ttf"
+	} else if ext != ".ttf" {
+		return "", errors.New("Only support font type ttf")
+	}
+
+	if filepath.IsAbs(fontpath) {
+		f, err := os.Open(fontpath)
+		if err != nil {
+			return "", err
+		}
+		f.Close()
+		return fontpath, nil
+	} else {
+		for _, d := range FontDirs {
+			p := filepath.Join(d, fontpath)
+			f, err := os.Open(p)
+			if err != nil {
+				continue
+			}
+			f.Close()
+			return p, nil
+		}
+		return "", errors.New("Failed to locate a font file " + fontpath)
+	}
 }
 
 // FontPath returns the path for a font name or an error if it is not found.
@@ -263,6 +297,15 @@ func initFontDirs() []string {
 
 	if len(dirs) == 0 {
 		dirs = []string{"./fonts"}
+	}
+
+	//add standard font dirs
+	home := os.Getenv("HOME")
+	switch runtime.GOOS {
+	case "darwin":
+		dirs = append(dirs, path.Join(home, "Library/Fonts"), "/Library/Fonts", "/System/Library/Fonts")
+	case "linux":
+		dirs = append(dirs, path.Join(home, ".fonts"), "/usr/share/fonts", "/usr/local/share/fonts")
 	}
 
 	return dirs

--- a/vg/font.go
+++ b/vg/font.go
@@ -234,20 +234,16 @@ func absFontPath(fontpath string) (string, error) {
 	}
 
 	if filepath.IsAbs(fontpath) {
-		f, err := os.Open(fontpath)
-		if err != nil {
+		if _, err := os.Lstat(fontpath); err != nil {
 			return "", err
 		}
-		f.Close()
 		return fontpath, nil
 	} else {
 		for _, d := range FontDirs {
 			p := filepath.Join(d, fontpath)
-			f, err := os.Open(p)
-			if err != nil {
+			if _, err := os.Lstat(p); err != nil {
 				continue
 			}
-			f.Close()
 			return p, nil
 		}
 		return "", errors.New("Failed to locate a font file " + fontpath)

--- a/vg/recorder/recorder_test.go
+++ b/vg/recorder/recorder_test.go
@@ -53,7 +53,7 @@ func TestRecorder(t *testing.T) {
 	replay.Reset()
 	rec.Actions = append(rec.Actions, &FillString{Font: "Foo", Size: 12, X: 0, Y: 10, String: "Bar"})
 	err = rec.ReplayOn(&replay)
-	if !strings.HasPrefix(err.Error(), "Unknown font: Foo.") {
+	if !strings.HasPrefix(err.Error(), "Failed to locate a font file Foo") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -259,7 +259,9 @@ func (c *Canvas) FillString(font vg.Font, x, y vg.Length, str string) {
 
 	data, ok := fontMap[font.Name()]
 	if !ok {
-		panic(fmt.Sprintf("Font name %s is unknown", font.Name()))
+		data = draw2d.FontData{
+			Name: font.Name(),
+		}
 	}
 	if !registeredFont[font.Name()] {
 		draw2d.RegisterFont(data, font.Font())


### PR DESCRIPTION
It will load font in the standard font dirs.
When want to use font  `/usr/share/fonts/font1.ttf`, just  `plot.DefaultFont ="font1"` will work.