### PR TITLE
make plotter tests idempotent in cases where they run to completion

### DIFF
--- a/plotter/general_test.go
+++ b/plotter/general_test.go
@@ -75,11 +75,11 @@ func checkPlot(ExampleFunc func(), t *testing.T, paths ...string) {
 			errored = true
 		}
 		if errored {
-			// If there has been an error, write out the golden image for inspection.
-			ext := filepath.Ext(path)
-			noext := strings.TrimSuffix(path, ext)
-			goldenPath := noext + "_golden" + ext
-			f, err := os.Create(filepath.Join("testdata", goldenPath))
+			// If there has been an error, write the golden image back to where it
+			// was originally and write the new image to a different file for comparison.
+
+			// Write golden image back to original location.
+			f, err = os.Create(filepath.Join("testdata", path))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -91,7 +91,24 @@ func checkPlot(ExampleFunc func(), t *testing.T, paths ...string) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Logf("golden image has been written out as %s", goldenPath)
+
+			// Write out errored image for comparison.
+			ext := filepath.Ext(path)
+			noext := strings.TrimSuffix(path, ext)
+			erroredPath := noext + "_errored" + ext
+			f, err := os.Create(filepath.Join("testdata", erroredPath))
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = f.Write(have)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = f.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("the new (errored) image has been written out as %s", erroredPath)
 		}
 	}
 }


### PR DESCRIPTION
This is in response to #252. Ideally, the golden images would only be edited in cases where the user requests it. However, in order for the example functions to use p.Save() (which is probably desirable to help people understand the example functions), they need to write directly to the file system every time. If we completely separate the test functions from the example functions, then we no longer have any assurance going forward that the example functions are current and produce the files in the 'testdata' directory.

As a compromise solution, I've changed checkPlot() so that it runs the function as before, which overwrites the golden image, but if the new image is different than the previous golden image, it writes out the previous golden image in it original location and writes out the new image with the "_errored" suffix.

A drawback of this is that if the test's don't run to completion---for example, if the hard drive runs out of space in the middle of the test---the golden images may not be reverted to their original versions. However, this problem would be apparent in a pull request comparison on github, so it is not too subtle.

Other options:

1. Instead of using p.Save() in the example functions, have them write to a buffer, which could be compared to the golden image without overwriting it. I think this would make the examples substantially more confusing. We could also use a "hidden" save function and explain that a user would normally use p.Save(), but I put this in a previous version and it was not popular.
2. Delete the example functions so that there are only test functions in the source code itself, and move the examples to a separate gallery. I'm skeptical of this because then the gallery would require separate maintenance to keep it current with the library, and i've seen cases in other libaries where the example functions don't run or they don't produce the advertised output, which is frustrating.