### PR TITLE
travis: workaround go-get-insecure for rsc.io/pdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 
 # Get coverage tools, and start the virtual framebuffer.
 before_install:
+ - git clone git://github.com/rsc/pdf $GOPATH/src/rsc.io/pdf
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
  - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
while the `go get rsc.io/pdf` failure is fixed upstream
(rsc/pdf#4), check out manually the repository from github and put it
in the correct place under $GOPATH.
