### PR TITLE
vg/vgtex: fix generation of PGF document

### DIFF
--- a/vg/vgtex/canvas.go
+++ b/vg/vgtex/canvas.go
@@ -262,7 +262,7 @@ func (c *Canvas) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	if c.document {
-		nn, err = w.Write([]byte(defaultFooter))
+		nn, err = b.Write([]byte(defaultFooter))
 		n += int64(nn)
 		if err != nil {
 			return n, err

--- a/vg/vgtex/testdata/scatter_golden.tex
+++ b/vg/vgtex/testdata/scatter_golden.tex
@@ -302,5 +302,5 @@
   \pgfsetstrokeopacity{1}
   \pgfsetfillopacity{1}
   \pgftext[base,at={\pgfpoint{73.86614173228347pt}{70.86614173228347pt}}]{x}
-\end{document}
 \end{pgfpicture}
+\end{document}


### PR DESCRIPTION
- fix a bug introduced by the `New`/`NewDocument` split.
- updated reference file.

this could have been caught if the generation of the PDF was performed during the test but... adding `LaTeX` as a test pre-requisite sounds less than ideal.