### PR TITLE
all: implement a more reliable image comparison

### DIFF
--- a/internal/cmpimg/cmpimg.go
+++ b/internal/cmpimg/cmpimg.go
@@ -1,0 +1,78 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// package cmpimg compares the raw representation of images taking into account idiosyncracies related to their underlying format (SVG, PDF, PNG, ...)
+package cmpimg
+
+import (
+	"bytes"
+	"image"
+	"reflect"
+
+	"rsc.io/pdf"
+)
+
+// Equal takes the raw representation of two images, raw1 and raw2,
+// together with the underlying image type ("pdf", "svg", ...), and returns
+// whether the two images are equal or not.
+//
+// Equal may return an error if the decoding of the raw image somehow failed.
+func Equal(typ string, raw1, raw2 []byte) (bool, error) {
+	switch typ {
+	case "svg":
+		return bytes.Equal(raw1, raw2), nil
+
+	case "pdf":
+		// TODO(sbinet): bytes.Reader.Size was introduced only after go-1.4
+		// use that if/when we drop go-1.4 bwd compat.
+		r1 := bytes.NewReader(raw1)
+		sz1 := int64(len(raw1))
+		pdf1, err := pdf.NewReader(r1, sz1)
+		if err != nil {
+			return false, err
+		}
+
+		// TODO(sbinet): bytes.Reader.Size was introduced only after go-1.4
+		// use that if/when we drop go-1.4 bwd compat.
+		r2 := bytes.NewReader(raw2)
+		sz2 := int64(len(raw2))
+		pdf2, err := pdf.NewReader(r2, sz2)
+		if err != nil {
+			return false, err
+		}
+
+		return cmpPdf(pdf1, pdf2), nil
+
+	default:
+		v1, _, err := image.Decode(bytes.NewReader(raw1))
+		if err != nil {
+			return false, err
+		}
+		v2, _, err := image.Decode(bytes.NewReader(raw2))
+		if err != nil {
+			return false, err
+		}
+		return reflect.DeepEqual(v1, v2), nil
+	}
+}
+
+func cmpPdf(pdf1, pdf2 *pdf.Reader) bool {
+	n1 := pdf1.NumPage()
+	n2 := pdf2.NumPage()
+	if n1 != n2 {
+		return false
+	}
+
+	for i := 1; i <= n1; i++ {
+		p1 := pdf1.Page(i).Content()
+		p2 := pdf2.Page(i).Content()
+		if !reflect.DeepEqual(p1, p2) {
+			return false
+		}
+	}
+
+	t1 := pdf1.Trailer().String()
+	t2 := pdf2.Trailer().String()
+	return t1 == t2
+}

--- a/internal/cmpimg/cmpimg.go
+++ b/internal/cmpimg/cmpimg.go
@@ -18,8 +18,8 @@ import (
 )
 
 // Equal takes the raw representation of two images, raw1 and raw2,
-// together with the underlying image type ("pdf", "svg", ...), and returns
-// whether the two images are equal or not.
+// together with the underlying image type ("eps", "jpeg", "jpg", "pdf", "png", "svg", "tiff"),
+// and returns whether the two images are equal or not.
 //
 // Equal may return an error if the decoding of the raw image somehow failed.
 func Equal(typ string, raw1, raw2 []byte) (bool, error) {

--- a/internal/cmpimg/cmpimg.go
+++ b/internal/cmpimg/cmpimg.go
@@ -7,9 +7,13 @@ package cmpimg
 
 import (
 	"bytes"
+	"fmt"
 	"image"
+	_ "image/jpeg"
+	_ "image/png"
 	"reflect"
 
+	_ "golang.org/x/image/tiff"
 	"rsc.io/pdf"
 )
 
@@ -21,6 +25,9 @@ import (
 func Equal(typ string, raw1, raw2 []byte) (bool, error) {
 	switch typ {
 	case "svg":
+		return bytes.Equal(raw1, raw2), nil
+
+	case "eps":
 		return bytes.Equal(raw1, raw2), nil
 
 	case "pdf":
@@ -44,7 +51,7 @@ func Equal(typ string, raw1, raw2 []byte) (bool, error) {
 
 		return cmpPdf(pdf1, pdf2), nil
 
-	default:
+	case "jpeg", "jpg", "png", "tiff":
 		v1, _, err := image.Decode(bytes.NewReader(raw1))
 		if err != nil {
 			return false, err
@@ -54,6 +61,9 @@ func Equal(typ string, raw1, raw2 []byte) (bool, error) {
 			return false, err
 		}
 		return reflect.DeepEqual(v1, v2), nil
+
+	default:
+		return false, fmt.Errorf("cmpimg: unknown image type %q", typ)
 	}
 }
 

--- a/plotter/general_test.go
+++ b/plotter/general_test.go
@@ -5,7 +5,6 @@
 package plotter
 
 import (
-	"bytes"
 	"flag"
 	"io/ioutil"
 	"log"
@@ -16,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gonum/plot"
+	"github.com/gonum/plot/internal/cmpimg"
 	"github.com/gonum/plot/vg"
 )
 
@@ -66,8 +66,15 @@ func checkPlot(ExampleFunc func(), t *testing.T, filenames ...string) {
 			t.Errorf("Failed to read golden file %s: %s", golden, err)
 			continue
 		}
-		if !bytes.Equal(got, want) {
+		typ := filepath.Ext(path)[1:] // remove the dot in e.g. ".pdf"
+		ok, err := cmpimg.Equal(typ, got, want)
+		if err != nil {
+			t.Errorf("failed to compare image for %s: %v\n", path, err)
+			continue
+		}
+		if !ok {
 			t.Errorf("image mismatch for %s\n", path)
+			continue
 		}
 	}
 }

--- a/vg/vg_test.go
+++ b/vg/vg_test.go
@@ -8,18 +8,15 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"image"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/gonum/plot"
+	"github.com/gonum/plot/internal/cmpimg"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
-	"rsc.io/pdf"
 )
 
 var generateTestData = flag.Bool("regen", false, "Uses the current state to regenerate the test data.")
@@ -68,88 +65,21 @@ func TestLineWidth(t *testing.T) {
 				}
 			}
 
-			switch typ {
-			case "svg":
-				want, err := ioutil.ReadFile(name)
-				if err != nil {
-					t.Fatalf("failed to read test image: %v", err)
-				}
+			want, err := ioutil.ReadFile(name)
+			if err != nil {
+				t.Fatalf("failed to read test image [%s]: %v\n", name, err)
+			}
 
-				if !bytes.Equal(buf.Bytes(), want) {
-					t.Errorf("image mismatch for %v:%s", w, typ)
-				}
+			ok, err := cmpimg.Equal(typ, buf.Bytes(), want)
+			if err != nil {
+				t.Fatalf("failed to run cmpimg test [%s]: %v\n", name, err)
+			}
 
-			case "pdf":
-				f, err := os.Open(name)
-				if err != nil {
-					t.Fatalf("failed to open test image: %v", err)
-				}
-				defer f.Close()
-				fi, err := f.Stat()
-				if err != nil {
-					t.Fatalf("failed to retrieve test image infos: %v", err)
-				}
-				want, err := pdf.NewReader(f, fi.Size())
-				if err != nil {
-					t.Fatalf("failed to decode test image (typ=%s): %v", typ, err)
-				}
-
-				r := bytes.NewReader(buf.Bytes())
-				// TODO(sbinet): bytes.Reader.Size was introduced only after go-1.4
-				// use that if/when we drop go-1.4 bwd compat.
-				sz := int64(len(buf.Bytes()))
-				got, err := pdf.NewReader(r, sz)
-				if err != nil {
-					t.Fatalf("failed to decode image (typ=%s): %v", typ, err)
-				}
-
-				if !cmpPdf(got, want) {
-					t.Errorf("image mismatch for %v:%s", w, typ)
-				}
-
-			default:
-				f, err := os.Open(name)
-				if err != nil {
-					t.Fatalf("failed to open test image: %v", err)
-				}
-				defer f.Close()
-
-				want, _, err := image.Decode(f)
-				if err != nil {
-					t.Fatalf("failed to read test image (typ=%s): %v", typ, err)
-				}
-
-				got, _, err := image.Decode(&buf)
-				if err != nil {
-					t.Fatalf("failed to decode image (typ=%s): %v", typ, err)
-				}
-
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("image mismatch for %v:%s", w, typ)
-				}
+			if !ok {
+				t.Errorf("image mismatch for %v:%s", w, typ)
 			}
 		}
 	}
-}
-
-func cmpPdf(pdf1, pdf2 *pdf.Reader) bool {
-	n1 := pdf1.NumPage()
-	n2 := pdf2.NumPage()
-	if n1 != n2 {
-		return false
-	}
-
-	for i := 1; i <= n1; i++ {
-		p1 := pdf1.Page(i).Content()
-		p2 := pdf2.Page(i).Content()
-		if !reflect.DeepEqual(p1, p2) {
-			return false
-		}
-	}
-
-	t1 := pdf1.Trailer().String()
-	t2 := pdf2.Trailer().String()
-	return t1 == t2
 }
 
 func lines(w vg.Length) (*plot.Plot, error) {


### PR DESCRIPTION
This CL introduces the internal package cmpimg which allows to reliably
compare whether two images are the same, taking into account
idiosyncracies of the gonum/plot-supported image formats.

Fixes #280