### PR TITLE
plotter: fix XY range and palette indexing calculations

### DIFF
--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -179,7 +179,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		xmin = -0.5
 	default:
 		xmax = (3*h.GridXYZ.X(c-1) - h.GridXYZ.X(c-2)) / 2
-		xmin = (h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
+		xmin = (3*h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
 	}
 	switch r {
 	case 1: // Make a unit length when there is no neighbour.
@@ -187,7 +187,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		ymin = -0.5
 	default:
 		ymax = (3*h.GridXYZ.Y(r-1) - h.GridXYZ.Y(r-2)) / 2
-		ymin = (h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
+		ymin = (3*h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
 	}
 	return xmin, xmax, ymin, ymax
 }

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -159,7 +159,7 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 			case v > h.Max:
 				col = h.Overflow
 			default:
-				col = pal[int((v-h.Min)*ps+0.5)] // Apply palette scaling.
+				col = pal[int((v-h.Min)*ps-0.5)] // Apply palette scaling.
 			}
 			if col != nil {
 				c.SetColor(col)


### PR DESCRIPTION
First image is prior broken code, only data for X>0, Y>0 shown, 2nd includes full X and Y value ranges, final image shifts palette index to avoid early saturation seen in top right of images.

![prior-onlyposx-posyshown](https://cloud.githubusercontent.com/assets/17184422/16705795/74eb2bca-4563-11e6-8bb2-6858efc7329c.png)
![fixed-fullmap](https://cloud.githubusercontent.com/assets/17184422/16705797/7960b350-4563-11e6-9ae4-75f8e9a43d9c.png)
![scalefix-noearlysaturationtopright](https://cloud.githubusercontent.com/assets/17184422/16705799/7e934a5e-4563-11e6-8208-0f1308dc9d36.png)

