### PR TITLE
Allow solid colored glyphs have a different colored outline

### DIFF
--- a/vg/draw/canvas.go
+++ b/vg/draw/canvas.go
@@ -55,6 +55,12 @@ type GlyphStyle struct {
 	// Radius specifies the size of the glyph's radius.
 	Radius vg.Length
 
+	// Width is set, LineColour is used to outline the glyph
+	Width vg.Length
+
+	// Outline glyph with this color if Width is set.
+	LineColor color.Color
+
 	// Shape draws the shape of the glyph.
 	Shape GlyphDrawer
 }
@@ -106,6 +112,11 @@ func (CircleGlyph) DrawGlyph(c *Canvas, sty GlyphStyle, pt vg.Point) {
 	p.Arc(pt, sty.Radius, 0, 2*math.Pi)
 	p.Close()
 	c.Fill(p)
+
+	if sty.Width > 0 {
+		c.SetLineStyle(LineStyle{Color: sty.LineColor, Width: sty.Width})
+		c.Stroke(p)
+	}
 }
 
 // RingGlyph is a glyph that draws the outline of a circle.
@@ -156,6 +167,11 @@ func (BoxGlyph) DrawGlyph(c *Canvas, sty GlyphStyle, pt vg.Point) {
 	p.Line(vg.Point{X: pt.X - x, Y: pt.Y + x})
 	p.Close()
 	c.Fill(p)
+
+	if sty.Width > 0 {
+		c.SetLineStyle(LineStyle{Color: sty.LineColor, Width: sty.Width})
+		c.Stroke(p)
+	}
 }
 
 // TriangleGlyph is a glyph that draws the outline of a triangle.
@@ -185,6 +201,11 @@ func (PyramidGlyph) DrawGlyph(c *Canvas, sty GlyphStyle, pt vg.Point) {
 	p.Line(vg.Point{X: pt.X + r*cosπover6, Y: pt.Y - r*sinπover6})
 	p.Close()
 	c.Fill(p)
+
+	if sty.Width > 0 {
+		c.SetLineStyle(LineStyle{Color: sty.LineColor, Width: sty.Width})
+		c.Stroke(p)
+	}
 }
 
 // PlusGlyph is a glyph that draws a plus sign


### PR DESCRIPTION
Here is an initial go at a patch that allows solid coloured Glyphs to have an outline.

A keen observer may note that an update to allow a `PyramidGlyph` to be solid coloured with an outline, is almost the same as if we had allowed `TriangleGlyph` to have a fill. (ditto for Box/Square, and Circle,Round).

There is probably a case for arguing that we don't need `PyramidGlyph` and `TriangleGlyph` as they are both the same except with a different fill or stroke colour, but I don't want such arguments to hold up a useful patch :D Can we patch first and argue how to present the API later?

Where in the past we may have done:

         p, err := plot.New()
         ....
         lpPoints.Shape = draw.CircleGlyph{}
         lpPoints.Color = color.RGBA{R: 255, G: 200, B: 200, A: 255}
         p.Add(lpLine, lpPoints)

We can now do:

         p, err := plot.New()
         ....
         lpPoints.Shape = draw.CircleGlyph{}
         lpPoints.Color = color.RGBA{R: 255, G: 200, B: 200, A: 255}
         lpPoints.Width = vg.Points(1.0)
         lpPoints.LineColor = lpLine.Color
         p.Add(lpLine, lpPoints)

