### PR TITLE
Plotter: Fix 0 depth heatmap issue

### DIFF
--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -179,7 +179,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		xmin = -0.5
 	default:
 		xmax = (3*h.GridXYZ.X(c-1) - h.GridXYZ.X(c-2)) / 2
-		xmin = (h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
+		xmin = (3*h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
 	}
 	switch r {
 	case 1: // Make a unit length when there is no neighbour.
@@ -187,7 +187,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		ymin = -0.5
 	default:
 		ymax = (3*h.GridXYZ.Y(r-1) - h.GridXYZ.Y(r-2)) / 2
-		ymin = (h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
+		ymin = (3*h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
 	}
 	return xmin, xmax, ymin, ymax
 }

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -159,7 +159,7 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 			case v > h.Max:
 				col = h.Overflow
 			default:
-				col = pal[int((v-h.Min)*ps+0.5)] // Apply palette scaling.
+				col = pal[int((v-h.Min)*ps-0.5)] // Apply palette scaling.
 			}
 			if col != nil {
 				c.SetColor(col)

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -98,11 +98,6 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 	}
 	// ps scales the palette uniformly across the data range.
 	ps := float64(len(pal)-1) / (h.Max - h.Min)
-	// for some degenerate data sets with h.Max == h.Min, this blows
-	// up and needs to be caught
-	if math.IsNaN(ps) {
-		ps = 0.0
-	}
 
 	trX, trY := plt.Transforms(&c)
 

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -164,7 +164,7 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 			case v > h.Max:
 				col = h.Overflow
 			default:
-				col = pal[int((v-h.Min)*ps-0.5)] // Apply palette scaling.
+				col = pal[int((v-h.Min)*ps+0.5)] // Apply palette scaling.
 			}
 			if col != nil {
 				c.SetColor(col)

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -184,7 +184,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		xmin = -0.5
 	default:
 		xmax = (3*h.GridXYZ.X(c-1) - h.GridXYZ.X(c-2)) / 2
-		xmin = (3*h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
+		xmin = (h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
 	}
 	switch r {
 	case 1: // Make a unit length when there is no neighbour.
@@ -192,7 +192,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		ymin = -0.5
 	default:
 		ymax = (3*h.GridXYZ.Y(r-1) - h.GridXYZ.Y(r-2)) / 2
-		ymin = (3*h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
+		ymin = (h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
 	}
 	return xmin, xmax, ymin, ymax
 }

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -98,6 +98,11 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 	}
 	// ps scales the palette uniformly across the data range.
 	ps := float64(len(pal)-1) / (h.Max - h.Min)
+	// for some degenerate data sets with h.Max == h.Min, this blows
+	// up and needs to be caught
+	if math.IsNaN(ps) {
+		ps = 0.0
+	}
 
 	trX, trY := plt.Transforms(&c)
 


### PR DESCRIPTION
Resolves #302 
If a data set happens to have 0 depth (min==max) the color scaling calculations blow up to NaN due to a divide by 0.  Catch this case to allow successfully returning a flat heatmap.
