### PR TITLE
Plotter:  Add tick label precision to dintinguish adjacent labels

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -373,7 +373,12 @@ func (DefaultTicks) Ticks(min, max float64) (ticks []Tick) {
 	}
 	majorDelta := float64(majorMult) * tens
 	val := math.Floor(min/majorDelta) * majorDelta
-	prec := maxInt(precisionOf(min), precisionOf(max))
+	// Precision required is not just to see a value for the ticks, but to
+	// measure and distinguish the tick points from each other accurately,
+	// limit is not to abrely resolve the min and max points, but to
+	// see the difference between points that are majorDelta away from each other
+	// /10 is more than needed, /2 probalby not enouth in all cases, so go with /3
+	prec := precisionOf(majorDelta / 3)
 	for val <= max {
 		if val >= min && val <= max {
 			ticks = append(ticks, Tick{Value: val, Label: formatFloatTick(val, prec)})

--- a/axis.go
+++ b/axis.go
@@ -374,11 +374,8 @@ func (DefaultTicks) Ticks(min, max float64) (ticks []Tick) {
 	majorDelta := float64(majorMult) * tens
 	val := math.Floor(min/majorDelta) * majorDelta
 	// Precision required is not just to see a value for the ticks, but to
-	// measure and distinguish the tick points from each other accurately,
-	// limit is not to abrely resolve the min and max points, but to
-	// see the difference between points that are majorDelta away from each other
-	// /10 is more than needed, /2 probalby not enouth in all cases, so go with /3
-	prec := precisionOf(majorDelta / 3)
+	// measure and distinguish the tick points from each other accurately
+	prec := precisionOf(majorDelta)
 	for val <= max {
 		if val >= min && val <= max {
 			ticks = append(ticks, Tick{Value: val, Label: formatFloatTick(val, prec)})

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -179,7 +179,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		xmin = -0.5
 	default:
 		xmax = (3*h.GridXYZ.X(c-1) - h.GridXYZ.X(c-2)) / 2
-		xmin = (h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
+		xmin = (3*h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
 	}
 	switch r {
 	case 1: // Make a unit length when there is no neighbour.
@@ -187,7 +187,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		ymin = -0.5
 	default:
 		ymax = (3*h.GridXYZ.Y(r-1) - h.GridXYZ.Y(r-2)) / 2
-		ymin = (h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
+		ymin = (3*h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
 	}
 	return xmin, xmax, ymin, ymax
 }

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -159,7 +159,7 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 			case v > h.Max:
 				col = h.Overflow
 			default:
-				col = pal[int((v-h.Min)*ps+0.5)] // Apply palette scaling.
+				col = pal[int((v-h.Min)*ps-0.5)] // Apply palette scaling.
 			}
 			if col != nil {
 				c.SetColor(col)

--- a/plotter/heat.go
+++ b/plotter/heat.go
@@ -159,7 +159,7 @@ func (h *HeatMap) Plot(c draw.Canvas, plt *plot.Plot) {
 			case v > h.Max:
 				col = h.Overflow
 			default:
-				col = pal[int((v-h.Min)*ps-0.5)] // Apply palette scaling.
+				col = pal[int((v-h.Min)*ps+0.5)] // Apply palette scaling.
 			}
 			if col != nil {
 				c.SetColor(col)
@@ -179,7 +179,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		xmin = -0.5
 	default:
 		xmax = (3*h.GridXYZ.X(c-1) - h.GridXYZ.X(c-2)) / 2
-		xmin = (3*h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
+		xmin = (h.GridXYZ.X(0) - h.GridXYZ.X(1)) / 2
 	}
 	switch r {
 	case 1: // Make a unit length when there is no neighbour.
@@ -187,7 +187,7 @@ func (h *HeatMap) DataRange() (xmin, xmax, ymin, ymax float64) {
 		ymin = -0.5
 	default:
 		ymax = (3*h.GridXYZ.Y(r-1) - h.GridXYZ.Y(r-2)) / 2
-		ymin = (3*h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
+		ymin = (h.GridXYZ.Y(0) - h.GridXYZ.Y(1)) / 2
 	}
 	return xmin, xmax, ymin, ymax
 }


### PR DESCRIPTION
Resolves #301

Previous precision limits guaranteed seeing at least one digit of major tick mark values; however, this was not enough to tell them apart, and all major tick marks could display the same value without precision to tell them apart.  This change increases minimum precision based on distance between the major tick marks to ensure that adjacent major labels can be distinguished from each other. 
![tickprecisionambiguity](https://cloud.githubusercontent.com/assets/17184422/16907243/cb0a39e6-4c8f-11e6-9d7b-21ffaebfe80d.png)
![tickprecisionimproved](https://cloud.githubusercontent.com/assets/17184422/16907242/cb0821c4-4c8f-11e6-9d82-98eaa4a0a4b6.png)

Note the colorbar tick labels for similar random test data sets before and after the change