### PR TITLE
Add draw.Split* functions

### DIFF
--- a/vg/draw/split_horiz_example_test.go
+++ b/vg/draw/split_horiz_example_test.go
@@ -1,0 +1,25 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package draw_test
+
+import (
+	"fmt"
+
+	"github.com/gonum/plot/vg"
+	"github.com/gonum/plot/vg/draw"
+)
+
+// SplitHorizontal returns the left and right portions of c after splitting it
+// along a vertical line distance x from the left of c.
+func SplitHorizontal(c draw.Canvas, x vg.Length) (left, right draw.Canvas) {
+	return draw.Crop(c, 0, c.Min.X-c.Max.X+x, 0, 0), draw.Crop(c, x, 0, 0, 0)
+}
+
+func ExampleCrop_splitHorizontal() {
+	var c draw.Canvas
+	// Split c along a vertical line centered on the canvas.
+	left, right := SplitHorizontal(c, c.Size().X/2)
+	fmt.Println(left.Rectangle.Size(), right.Rectangle.Size())
+}

--- a/vg/draw/split_vertical_example_test.go
+++ b/vg/draw/split_vertical_example_test.go
@@ -1,0 +1,26 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package draw_test
+
+import (
+	"fmt"
+
+	"github.com/gonum/plot/vg"
+	"github.com/gonum/plot/vg/draw"
+)
+
+// SplitVertical returns the lower and upper portions of c after
+// splitting it along a horizontal line distance y from the
+// bottom of c.
+func SplitVertical(c draw.Canvas, y vg.Length) (lower, upper draw.Canvas) {
+	return draw.Crop(c, 0, 0, 0, c.Min.Y-c.Max.Y+y), draw.Crop(c, 0, 0, y, 0)
+}
+
+func ExampleCrop_splitVertical() {
+	var c draw.Canvas
+	// Split c along a horizontal line centered on the canvas.
+	bottom, top := SplitHorizontal(c, c.Size().Y/2)
+	fmt.Println(bottom.Rectangle.Size(), top.Rectangle.Size())
+}


### PR DESCRIPTION
These are convenience functions that would be useful for instance in splitting up a canvas to put a plot in one part and a color bar in the other part. They are not strictly necessary but I feel like it's worthwhile to have them there because Crop can be pretty confusing to use.