### PR TITLE
vg: restore FontDirs initialization

### DIFF
--- a/vg/font.go
+++ b/vg/font.go
@@ -23,13 +23,6 @@ import (
 	"github.com/gonum/plot/vg/fonts"
 )
 
-const (
-	// importString is the import string expected for
-	// this package.  It is used to find the font
-	// directory included with the package source.
-	importString = "github.com/gonum/plot/vg"
-)
-
 var (
 	// FontMap maps Postscript/PDF font names to compatible
 	// free fonts (TrueType converted ghostscript fonts).

--- a/vg/font_syscall.go
+++ b/vg/font_syscall.go
@@ -12,8 +12,15 @@ import (
 	"path/filepath"
 )
 
+const (
+	// importString is the import string expected for
+	// this package.  It is used to find the font
+	// directory included with the package source.
+	importString = "github.com/gonum/plot/vg"
+)
+
 func init() {
-	initFontDirs()
+	FontDirs = initFontDirs()
 }
 
 // InitFontDirs returns the initial value for the FontDirectories variable.

--- a/vg/font_syscall_test.go
+++ b/vg/font_syscall_test.go
@@ -1,0 +1,19 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !js
+
+package vg_test
+
+import (
+	"testing"
+
+	"github.com/gonum/plot/vg"
+)
+
+func TestVGFONTPATH(t *testing.T) {
+	if len(vg.FontDirs) == 0 {
+		t.Fatalf("zero length FontDirs")
+	}
+}


### PR DESCRIPTION
PR gonum/plot#335 moved the vg-syscall into a different file to support
gopherjs.
But it dropped the initialization of the FontDirs global variable.
Fix this and also move the global const 'importString' closer to its
usage, in vg/font_syscall.go.

Add a test to make sure we don't regress.