### PR TITLE
plotter: allow user control of NaN values

### DIFF
--- a/plotter/heat_test.go
+++ b/plotter/heat_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gonum/plot/palette"
 	"github.com/gonum/plot/vg"
 	"github.com/gonum/plot/vg/draw"
-	"github.com/gonum/plot/vg/recorder"
 	"github.com/gonum/plot/vg/vgimg"
 )
 
@@ -107,34 +106,4 @@ func ExampleHeatMap() {
 
 func TestHeatMap(t *testing.T) {
 	cmpimg.CheckPlot(ExampleHeatMap, t, "heatMap.png")
-}
-
-func TestFlatHeat(t *testing.T) {
-	m := offsetUnitGrid{
-		XOffset: -2,
-		YOffset: -1,
-		Data:    mat.NewDense(3, 4, nil),
-	}
-	h := NewHeatMap(m, palette.Heat(12, 1))
-
-	p, err := plot.New()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	p.Add(h)
-
-	func() {
-		defer func() {
-			r := recover()
-			if r == nil {
-				t.Error("expected panic for flat data")
-			}
-			const want = "heatmap: non-positive Z range"
-			if r != want {
-				t.Errorf("unexpected panic message: got:%q want:%q", r, want)
-			}
-		}()
-		c := draw.NewCanvas(new(recorder.Canvas), 72, 72)
-		p.Draw(c)
-	}()
 }


### PR DESCRIPTION
Also use this to allow plotting of ambiguously colour-mapping values
arising from when the Z-range is zero.

Fixes #302.

@eaburns @btracey @jasonpfox Please take a look.
