### PR TITLE
fixes-336: Extend the Ticker interface to allow passing a format function

### DIFF
--- a/axis_test.go
+++ b/axis_test.go
@@ -42,7 +42,7 @@ func TestAxisSmallTick(t *testing.T) {
 			want: []string{"0.0001", "0.00011", "0.00012", "0.00013", "0.00014"},
 		},
 	} {
-		ticks := d.Ticks(test.min, test.max)
+		ticks := d.Ticks(test.min, test.max, nil)
 		got := labelsOf(ticks)
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("tick labels mismatch:\ngot: %q\nwant:%q", got, test.want)

--- a/gob/gob_test.go
+++ b/gob/gob_test.go
@@ -129,8 +129,8 @@ func randomPoints(n int, rnd *rand.Rand) plotter.XYs {
 // into the labels for the major tick marks.
 type commaTicks struct{}
 
-func (commaTicks) Ticks(min, max float64) []plot.Tick {
-	tks := plot.DefaultTicks{}.Ticks(min, max)
+func (commaTicks) Ticks(min, max float64, format func(v float64, prec int) string) []plot.Tick {
+	tks := plot.DefaultTicks{}.Ticks(min, max, nil)
 	for i, t := range tks {
 		if t.Label == "" { // Skip minor ticks, they are fine.
 			continue

--- a/plotter/grid.go
+++ b/plotter/grid.go
@@ -53,7 +53,7 @@ func (g *Grid) Plot(c draw.Canvas, plt *plot.Plot) {
 	if g.Vertical.Color == nil {
 		goto horiz
 	}
-	for _, tk := range plt.X.Tick.Marker.Ticks(plt.X.Min, plt.X.Max) {
+	for _, tk := range plt.X.Tick.Marker.Ticks(plt.X.Min, plt.X.Max, nil) {
 		if tk.IsMinor() {
 			continue
 		}
@@ -68,7 +68,7 @@ horiz:
 	if g.Horizontal.Color == nil {
 		return
 	}
-	for _, tk := range plt.Y.Tick.Marker.Ticks(plt.Y.Min, plt.Y.Max) {
+	for _, tk := range plt.Y.Tick.Marker.Ticks(plt.Y.Min, plt.Y.Max, nil) {
 		if tk.IsMinor() {
 			continue
 		}


### PR DESCRIPTION
This allows for easy wrappers around the plot.DefaultTicks struct with
custom format functions:

````
    type myCustomFormatTicks struct{}

    var _ plot.Ticker = myCustomFormatTicks{}

    func (myCustomFormatTicks) Ticks(min, max float64, format func(v float64, prec int) string) (ticks []plot.Tick) {
      return plot.DefaultTicks{}.Ticks(min, max, myFormatFloatTick)
    }

    func myFormatFloatTick(v float64, prec int) string {
           return strconv.FormatFloat(floats.Round(v, prec), 'g', 8, 64)
    }

    p.Y.Tick.Marker = myCustomFormatTicks{}
````