### PR TITLE
travis: enable fast-finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
  - 1.8.x
  - master
 matrix:
+  fast_finish: true
   allow_failures:
     - go: master
 


### PR DESCRIPTION
This CL enables the fast-finish mode for travis.
See:
 https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/