### PR TITLE
plot: fix axis test build

### DIFF
--- a/axis_test.go
+++ b/axis_test.go
@@ -5,7 +5,6 @@
 package plot
 
 import (
-	"math"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
Commit e7f526d disabled a few tests.
But they were the only ones that needed "math".

Remove (temporarily) the import of "math".