### PR TITLE
vg/fonts: update base URL of Liberation fonts

### DIFF
--- a/vg/fonts/mk-fonts.go
+++ b/vg/fonts/mk-fonts.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	baseUrl   = "https://fedorahosted.org/releases/l/i/liberation-fonts/"
+	baseUrl   = "https://releases.pagure.org/liberation-fonts/"
 	fontsName = "liberation-fonts-ttf-2.00.1"
 )
 


### PR DESCRIPTION
The fedorahosted.org site has been retired (since March 2017.)
This CL now downloads fonts from the new location, pagure.org.

Fixes gonum/plot#400.