### PR TITLE
plotter: embed XY interface in XYZ, fix doc comment

### DIFF
--- a/plotter/plotter.go
+++ b/plotter/plotter.go
@@ -176,14 +176,10 @@ func (ys YValues) Value(i int) float64 {
 
 // XYZer wraps the Len and XYZ methods.
 type XYZer interface {
-	// Len returns the number of x, y, z triples.
-	Len() int
+	XYer
 
 	// XYZ returns an x, y, z triple.
 	XYZ(int) (float64, float64, float64)
-
-	// XY returns an x, y pair.
-	XY(int) (float64, float64)
 }
 
 // XYZs implements the XYZer interface using a slice.
@@ -199,7 +195,7 @@ func (xyz XYZs) XYZ(i int) (float64, float64, float64) {
 	return xyz[i].X, xyz[i].Y, xyz[i].Z
 }
 
-// XY implements the XY method of the XYer interface.
+// XY implements the XY method of the XYZer interface.
 func (xyz XYZs) XY(i int) (float64, float64) {
 	return xyz[i].X, xyz[i].Y
 }


### PR DESCRIPTION
* Better to embed the interface so changes to `XYer` automatically get moved to `XYZer`
* Fix doc comment to reflect that the `XY` method (for a `XYZs`) is for `XYZer` interface, not `XYer` interface (though it is technically correct as `XY` is embedded from the `XYer`, it's simpler to read this way)

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
