### PR TITLE
go.mod: fix stale gonum dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jung-kurt/gofpdf v1.0.0
 	github.com/llgcode/draw2d v0.0.0-20180124133339-274031cf2abe
 	github.com/llgcode/ps v0.0.0-20150911083025-f1443b32eedb // indirect
-	golang.org/x/image v0.0.0-20180403161127-f315e4403028
-	gonum.org/v1/gonum v0.0.0-20180710080948-ff99a9821f0f
+	golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81
+	gonum.org/v1/gonum v0.0.0-20180716103638-023b8e605abb
 	rsc.io/pdf v0.1.1
 )


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
