### PR TITLE
plotter: fix histogram hang for zero-width data range

### DIFF
--- a/plotter/histogram.go
+++ b/plotter/histogram.go
@@ -150,7 +150,7 @@ func (h *Histogram) Thumbnail(c *draw.Canvas) {
 // then a reasonable default is used.  The
 // default is the square root of the sum of
 // the y values.
-func binPoints(xys XYer, n int) ([]HistogramBin, float64) {
+func binPoints(xys XYer, n int) (bins []HistogramBin, width float64) {
 	xmin, xmax := Range(XValues{xys})
 	if n <= 0 {
 		m := 0.0
@@ -164,9 +164,12 @@ func binPoints(xys XYer, n int) ([]HistogramBin, float64) {
 		n = 1
 	}
 
-	bins := make([]HistogramBin, n)
+	bins = make([]HistogramBin, n)
 
 	w := (xmax - xmin) / float64(n)
+	if w == 0 {
+		w = 1
+	}
 	for i := range bins {
 		bins[i].Min = xmin + float64(i)*w
 		bins[i].Max = xmin + float64(i+1)*w


### PR DESCRIPTION
Please take a look.

Fixes #459.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
