### PR TITLE
plotter: Ensure Sankey stock color works without setting default

### DIFF
--- a/plotter/sankey.go
+++ b/plotter/sankey.go
@@ -264,8 +264,7 @@ func (s *Sankey) Plot(c draw.Canvas, plt *plot.Plot) {
 			{catMax, valMax},
 			{catMax, valMin},
 		}
-		if s.Color != nil {
-			// poly := c.ClipPolygonX(pts) // This causes half of the bar to disappear. Is there a best practice here?
+		if color != nil {
 			c.FillPolygon(color, pts) // poly)
 		}
 		txtPt := vg.Point{X: (catMin+catMax)/2 + xOff, Y: (valMin+valMax)/2 + yOff}

--- a/plotter/sankey_test.go
+++ b/plotter/sankey_test.go
@@ -383,14 +383,11 @@ func ExampleSankey_grouped() {
 			_, yTr := p.Transforms(&dc)
 			barHeight := yTr(max) - yTr(min)
 			if sankey.TextStyle.Font.Width(label) > barHeight {
-				return "large", sankey.TextStyle, 0, 0, sankey.Color, sankey.LineStyle
+				return "large", sankey.TextStyle, 0, 0, color.White, sankey.LineStyle
 			}
 		}
-		return label, sankey.TextStyle, 0, 0, sankey.Color, sankey.LineStyle
+		return label, sankey.TextStyle, 0, 0, color.White, sankey.LineStyle
 	}
-
-	// Here we set the backgroud color for stocks from grey to white.
-	sankey.Color = color.White
 
 	p.Add(sankey)
 	p.Y.Label.Text = "Number of fruit pieces"


### PR DESCRIPTION
Previously, the stock color could only be edited if a default was set.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
