### PR TITLE
vgimg: Add option to specify image background color.

### DIFF
--- a/vg/vgimg/vgimg_test.go
+++ b/vg/vgimg/vgimg_test.go
@@ -6,10 +6,13 @@ package vgimg_test
 
 import (
 	"bytes"
+	"fmt"
+	"image/color"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -69,4 +72,19 @@ func TestConcurrentInit(t *testing.T) {
 		wg.Done()
 	}()
 	wg.Wait()
+}
+
+func TestUseBackgroundColor(t *testing.T) {
+	colors := []color.Color{color.Transparent, color.NRGBA{R: 255, A: 255}}
+	for i, col := range colors {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			c := vgimg.NewWith(vgimg.UseWH(1, 1), vgimg.UseBackgroundColor(col))
+			img := c.Image()
+			wantCol := color.RGBAModel.Convert(col)
+			haveCol := img.At(0, 0)
+			if !reflect.DeepEqual(haveCol, wantCol) {
+				t.Fatalf("color should be %#v but is %#v", wantCol, haveCol)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Previously, the background color was always white, with no 
straightforward way to specify a transparent backgroun.

This is an alternative to #476 .

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
