### PR TITLE
plotter: add XY and XYZ struct type

### DIFF
--- a/plotter/plotter.go
+++ b/plotter/plotter.go
@@ -128,7 +128,10 @@ func XYRange(xys XYer) (xmin, xmax, ymin, ymax float64) {
 }
 
 // XYs implements the XYer interface.
-type XYs []struct{ X, Y float64 }
+type XYs []XY
+
+// XY is an x and y value.
+type XY struct{ X, Y float64 }
 
 // CopyXYs returns an XYs that is a copy of the x and y values from
 // an XYer, or an error if one of the data points contains a NaN or
@@ -187,7 +190,10 @@ type XYZer interface {
 }
 
 // XYZs implements the XYZer interface using a slice.
-type XYZs []struct{ X, Y, Z float64 }
+type XYZs []XYZ
+
+// XYZ is an x, y and z value.
+type XYZ struct{ X, Y, Z float64 }
 
 // Len implements the Len method of the XYZer interface.
 func (xyz XYZs) Len() int {


### PR DESCRIPTION
Fixes gonum/plot#494.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
