### PR TITLE
plot: rename log into logf

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -166,9 +166,16 @@ var _ Normalizer = LogScale{}
 
 // Normalize returns the fractional logarithmic distance of
 // x between min and max.
-func (LogScale) Normalize(min, max, x float64) float64 {
-	logMin := logf(min)
-	return (logf(x) - logMin) / (logf(max) - logMin)
+func (ls LogScale) Normalize(min, max, x float64) float64 {
+	logMin := ls.log(min)
+	return (ls.log(x) - logMin) / (ls.log(max) - logMin)
+}
+
+func (LogScale) log(x float64) float64 {
+	if x <= 0 {
+		panic("Values must be greater than 0 for a log scale.")
+	}
+	return math.Log(x)
 }
 
 // InvertedScale can be used as the value of an Axis.Scale function to
@@ -608,13 +615,6 @@ func tickLabelWidth(sty draw.TextStyle, ticks []Tick) vg.Length {
 		}
 	}
 	return maxWidth
-}
-
-func logf(x float64) float64 {
-	if x <= 0 {
-		panic("Values must be greater than 0 for a log scale.")
-	}
-	return math.Log(x)
 }
 
 // formatFloatTick returns a g-formated string representation of v

--- a/axis.go
+++ b/axis.go
@@ -167,8 +167,8 @@ var _ Normalizer = LogScale{}
 // Normalize returns the fractional logarithmic distance of
 // x between min and max.
 func (LogScale) Normalize(min, max, x float64) float64 {
-	logMin := log(min)
-	return (log(x) - logMin) / (log(max) - logMin)
+	logMin := logf(min)
+	return (logf(x) - logMin) / (logf(max) - logMin)
 }
 
 // InvertedScale can be used as the value of an Axis.Scale function to
@@ -610,7 +610,7 @@ func tickLabelWidth(sty draw.TextStyle, ticks []Tick) vg.Length {
 	return maxWidth
 }
 
-func log(x float64) float64 {
+func logf(x float64) float64 {
 	if x <= 0 {
 		panic("Values must be greater than 0 for a log scale.")
 	}

--- a/axis.go
+++ b/axis.go
@@ -166,16 +166,12 @@ var _ Normalizer = LogScale{}
 
 // Normalize returns the fractional logarithmic distance of
 // x between min and max.
-func (ls LogScale) Normalize(min, max, x float64) float64 {
-	logMin := ls.log(min)
-	return (ls.log(x) - logMin) / (ls.log(max) - logMin)
-}
-
-func (LogScale) log(x float64) float64 {
-	if x <= 0 {
+func (LogScale) Normalize(min, max, x float64) float64 {
+	if min <= 0 || max <= 0 || x <= 0 {
 		panic("Values must be greater than 0 for a log scale.")
 	}
-	return math.Log(x)
+	logMin := math.Log(min)
+	return (math.Log(x) - logMin) / (math.Log(max) - logMin)
 }
 
 // InvertedScale can be used as the value of an Axis.Scale function to


### PR DESCRIPTION
Having a function named `log` is relatively annoying when one is
debugging, especially in conjunction with `goimports`:
adding `log.Fatalf("foo")` statements is confusing `goimports` as a
function with the name `log` is already defined.

Rename `log` into `logf`.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
