### PR TITLE
vg/vgsvg: fix font size handling again

### DIFF
--- a/plotter/testdata/polygon_holes_golden.svg
+++ b/plotter/testdata/polygon_holes_golden.svg
@@ -6,15 +6,15 @@
 <g transform="scale(1, -1) translate(0, -100)">
 <path d="M0,0L100,0L100,100L0,100Z" style="fill:#FFFFFF" />
 <text x="3.6641" y="-88.445" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Polygon with holes</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Polygon with holes</text>
 <text x="62.75" y="-3.8613" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">X</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">X</text>
 <text x="34.166" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0</text>
 <text x="64.583" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">2</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">2</text>
 <text x="95" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">4</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">4</text>
 <path d="M36.666,25.23L36.666,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M67.083,25.23L67.083,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M97.5,25.23L97.5,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
@@ -23,14 +23,14 @@
 <path d="M36.666,33.23L97.5,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <g transform="rotate(90)">
 <text x="54.746" y="11.555" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Y</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Y</text>
 </g>
 <text x="15.416" y="-33.759" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0</text>
 <text x="15.416" y="-54.357" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">2</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">2</text>
 <text x="15.416" y="-74.955" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">4</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">4</text>
 <path d="M22.916,38.48L30.916,38.48" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M22.916,59.079L30.916,59.079" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M22.916,79.677L30.916,79.677" style="fill:none;stroke:#000000;stroke-width:0.5" />
@@ -44,6 +44,6 @@
 <path d="M90,38.48L90,46.332L100,46.332L100,38.48Z" style="fill:#0000FF" />
 <path d="M90,38.48L90,46.332L100,46.332L100,38.48L90,38.48" style="fill:none;stroke:#000000" />
 <text x="76.449" y="-38.629" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:8;fill:#FFFFFF">key</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:8px;fill:#FFFFFF">key</text>
 </g>
 </svg>

--- a/vg/testdata/width_-1.svg
+++ b/vg/testdata/width_-1.svg
@@ -6,13 +6,13 @@
 <g transform="scale(1, -1) translate(0, -100)">
 <path d="M0,0L100,0L100,100L0,100Z" style="fill:#FFFFFF" />
 <text x="51.465" y="-3.8613" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">X label</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">X label</text>
 <text x="37.916" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="62.708" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="87.5" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M44.166,25.23L44.166,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M68.958,25.23L68.958,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M93.75,25.23L93.75,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
@@ -27,14 +27,14 @@
 <path d="M44.166,33.23L93.75,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <g transform="rotate(90)">
 <text x="49.516" y="11.555" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Y label</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Y label</text>
 </g>
 <text x="15.416" y="-33.759" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="15.416" y="-62.065" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="15.416" y="-90.371" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M30.416,38.48L38.416,38.48" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,66.787L38.416,66.787" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,95.093L38.416,95.093" style="fill:none;stroke:#000000;stroke-width:0.5" />

--- a/vg/testdata/width_0.svg
+++ b/vg/testdata/width_0.svg
@@ -6,13 +6,13 @@
 <g transform="scale(1, -1) translate(0, -100)">
 <path d="M0,0L100,0L100,100L0,100Z" style="fill:#FFFFFF" />
 <text x="51.465" y="-3.8613" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">X label</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">X label</text>
 <text x="37.916" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="62.708" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="87.5" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M44.166,25.23L44.166,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M68.958,25.23L68.958,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M93.75,25.23L93.75,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
@@ -27,14 +27,14 @@
 <path d="M44.166,33.23L93.75,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <g transform="rotate(90)">
 <text x="49.516" y="11.555" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Y label</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Y label</text>
 </g>
 <text x="15.416" y="-33.759" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="15.416" y="-62.065" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="15.416" y="-90.371" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M30.416,38.48L38.416,38.48" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,66.787L38.416,66.787" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,95.093L38.416,95.093" style="fill:none;stroke:#000000;stroke-width:0.5" />

--- a/vg/testdata/width_1.svg
+++ b/vg/testdata/width_1.svg
@@ -6,13 +6,13 @@
 <g transform="scale(1, -1) translate(0, -100)">
 <path d="M0,0L100,0L100,100L0,100Z" style="fill:#FFFFFF" />
 <text x="51.465" y="-3.8613" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">X label</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">X label</text>
 <text x="37.916" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="62.708" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="87.5" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M44.166,25.23L44.166,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M68.958,25.23L68.958,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M93.75,25.23L93.75,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
@@ -27,14 +27,14 @@
 <path d="M44.166,33.23L93.75,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <g transform="rotate(90)">
 <text x="49.516" y="11.555" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Y label</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Y label</text>
 </g>
 <text x="15.416" y="-33.759" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="15.416" y="-62.065" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="15.416" y="-90.371" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M30.416,38.48L38.416,38.48" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,66.787L38.416,66.787" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,95.093L38.416,95.093" style="fill:none;stroke:#000000;stroke-width:0.5" />

--- a/vg/vgsvg/testdata/scatter_golden.svg
+++ b/vg/vgsvg/testdata/scatter_golden.svg
@@ -6,15 +6,15 @@
 <g transform="scale(1, -1) translate(0, -141.73)">
 <path d="M0,0L141.73,0L141.73,141.73L0,141.73Z" style="fill:#FFFFFF" />
 <text x="43.374" y="-130.18" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Scatter plot</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Scatter plot</text>
 <text x="86.741" y="-3.8613" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">X</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">X</text>
 <text x="40.416" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="84.824" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="129.23" y="-15.602" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M46.666,25.23L46.666,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M91.074,25.23L91.074,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M135.48,25.23L135.48,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
@@ -29,14 +29,14 @@
 <path d="M46.666,33.23L135.48,33.23" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <g transform="rotate(90)">
 <text x="76.862" y="11.555" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12">Y</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:12px">Y</text>
 </g>
 <text x="15.416" y="-36.259" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.0</text>
 <text x="15.416" y="-76.473" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">0.5</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">0.5</text>
 <text x="15.416" y="-116.69" transform="scale(1, -1)"
-	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10">1.0</text>
+	style="font-family:Times;font-weight:normal;font-style:normal;font-size:10px">1.0</text>
 <path d="M30.416,40.98L38.416,40.98" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,81.195L38.416,81.195" style="fill:none;stroke:#000000;stroke-width:0.5" />
 <path d="M30.416,121.41L38.416,121.41" style="fill:none;stroke:#000000;stroke-width:0.5" />

--- a/vg/vgsvg/vgsvg.go
+++ b/vg/vgsvg/vgsvg.go
@@ -296,7 +296,7 @@ func (c *Canvas) FillString(font vg.Font, pt vg.Point, str string) {
 		panic(fmt.Sprintf("Unknown font: %s", font.Name()))
 	}
 	sty := style(fontStr,
-		elm("font-size", "medium", "%.*g", pr, font.Size.Points()),
+		elm("font-size", "medium", "%.*gpx", pr, font.Size.Points()),
 		elm("fill", "#000000", colorString(c.context().color)))
 	if sty != "" {
 		sty = "\n\t" + sty


### PR DESCRIPTION
#507 apparently did not fix font size handling for all SVG renderers. It did for my machine locally (eog, the file dialogue preview and firefox all render the test outputs correctly), and according to the spec it should.

Please take a look.

I'd like to suggest we submit a proposal to the W3C that the XML spec should be loosened to allow anythin that contains left and right anlge brackets, with the semantic of the text to be "What was intended". This would at a single step fix all XML data processing globally, and bring the spec into line with current usage.

/cc @chmike

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
