### PR TITLE
vg/vgpdf: fix example name for GoDoc

### DIFF
--- a/vg/vgpdf/vgpdf_test.go
+++ b/vg/vgpdf/vgpdf_test.go
@@ -19,9 +19,9 @@ import (
 	"gonum.org/v1/plot/vg/vgpdf"
 )
 
-// ExampleEmbedFonts shows how one can embed (or not) fonts inside
+// Example_embedFonts shows how one can embed (or not) fonts inside
 // a PDF plot.
-func ExampleEmbedFonts() {
+func Example_embedFonts() {
 	p, err := plot.New()
 	if err != nil {
 		log.Fatalf("could not create plot: %v", err)


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
