### PR TITLE
coveralls: paper over service flakiness

### DIFF
--- a/.travis/test-coverage.sh
+++ b/.travis/test-coverage.sh
@@ -31,5 +31,5 @@ echo "mode: set" > $ACC_OUT
 find . -maxdepth 10 -type d | while read d; do testCover $d || exit; done
 
 # Upload the coverage profile to coveralls.io
-[ -n "$COVERALLS_TOKEN" ] && goveralls -coverprofile=$ACC_OUT -service=travis-ci -repotoken $COVERALLS_TOKEN
+[ -n "$COVERALLS_TOKEN" ] && ( goveralls -coverprofile=$ACC_OUT -service=travis-ci -repotoken $COVERALLS_TOKEN || echo -e '\n\e[31mCoveralls failed.\n' )
 


### PR DESCRIPTION
Coveralls has been really flakey for the past few days, failing to collect data from builds and causing otherwise successful builds to fail. There appears to be a long history to this, so rather than losing/hiding success information just warn on Coveralls failure.

Please take a look.

Ameliorates lemurheavy/coveralls-public#1264.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
