### PR TITLE
vgimg: translate to gg arc end point concept

### DIFF
--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -258,7 +258,7 @@ func (c *Canvas) outline(p vg.Path) {
 		case vg.ArcComp:
 			c.ctx.DrawArc(comp.Pos.X.Dots(c.DPI()), comp.Pos.Y.Dots(c.DPI()),
 				comp.Radius.Dots(c.DPI()),
-				comp.Start, comp.Angle,
+				comp.Start, comp.Start+comp.Angle,
 			)
 
 		case vg.CurveComp:


### PR DESCRIPTION
This concerts from (theta,phi) that is used by vg to (theta_1,theta_2) that is used by gg.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
