### PR TITLE
ci: use GOPROXY from proxy.golang.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   global:
    - DISPLAY: ":99.0"
    - GO111MODULE: "on"
+   - GOPROXY: "https://proxy.golang.org"
 
 # Get coverage tools, and start the virtual framebuffer.
 before_install:


### PR DESCRIPTION
Using this proxy allows to push and then use the latest gonum/plot version
from the playground.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
