### PR TITLE
ci: remove xvfb initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
 
 env:
   global:
-   - DISPLAY: ":99.0"
    - GO111MODULE: "on"
 
 # Get coverage tools, and start the virtual framebuffer.
@@ -30,7 +29,6 @@ before_install:
  # Required for coverage.
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
- - sh -e /etc/init.d/xvfb start
 
 # Get deps, build, test, and ensure the code is gofmt'ed.
 # If we are building as gonum, then we have access to the coveralls api key, so we can run coverage as well.


### PR DESCRIPTION
In 4f1973df78022b5113212a4502cdd3a7cf1c8d5c, we added bootstrap code
to fix #179 and start xvfb for the benefit of the vg/vgx11 backend.

vg/vgx11 has since been removed from gonum/plot.
So remove the xvfb startup as well.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
