### PR TITLE
vg/vgimg: document that images are copied in UseImage

### DIFF
--- a/vg/vgimg/vgimg.go
+++ b/vg/vgimg/vgimg.go
@@ -146,6 +146,10 @@ func UseDPI(dpi int) option {
 // the canvas from. The
 // minimum point of the given image
 // should probably be 0,0.
+//
+// Note that a copy of the input image is performed.
+// This means that modifications applied to the canvas are not reflected
+// on the original image.
 func UseImage(img draw.Image) option {
 	return func(c *Canvas) uint32 {
 		c.img = img


### PR DESCRIPTION
Fixes #570.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
