### PR TITLE
vg/draw: add support for .tex to NewFormattedCanvas and plot.Plot.Save

### DIFF
--- a/vg/draw/canvas.go
+++ b/vg/draw/canvas.go
@@ -15,6 +15,7 @@ import (
 	"gonum.org/v1/plot/vg/vgimg"
 	"gonum.org/v1/plot/vg/vgpdf"
 	"gonum.org/v1/plot/vg/vgsvg"
+	"gonum.org/v1/plot/vg/vgtex"
 )
 
 // A Canvas is a vector graphics canvas along with
@@ -268,7 +269,7 @@ func New(c vg.CanvasSizer) Canvas {
 //
 // Supported formats are:
 //
-//  eps, jpg|jpeg, pdf, png, svg, and tif|tiff.
+//  eps, jpg|jpeg, pdf, png, svg, tex and tif|tiff.
 func NewFormattedCanvas(w, h vg.Length, format string) (vg.CanvasWriterTo, error) {
 	var c vg.CanvasWriterTo
 	switch format {
@@ -286,6 +287,9 @@ func NewFormattedCanvas(w, h vg.Length, format string) (vg.CanvasWriterTo, error
 
 	case "svg":
 		c = vgsvg.New(w, h)
+
+	case "tex":
+		c = vgtex.NewDocument(w, h)
 
 	case "tif", "tiff":
 		c = vgimg.TiffCanvas{Canvas: vgimg.New(w, h)}

--- a/vg/draw/draw_test.go
+++ b/vg/draw/draw_test.go
@@ -5,6 +5,7 @@
 package draw
 
 import (
+	"fmt"
 	"image/color"
 	"reflect"
 	"testing"
@@ -113,5 +114,46 @@ func TestTile(t *testing.T) {
 				t.Errorf(str, j, i, tile.Rectangle, rectangles[j][i])
 			}
 		}
+	}
+}
+
+func TestFormattedCanvas(t *testing.T) {
+	for _, test := range []struct {
+		format string
+		err    error
+	}{
+		{format: "eps"},
+		{format: "jpg"},
+		{format: "jpeg"},
+		{format: "pdf"},
+		{format: "png"},
+		{format: "svg"},
+		{format: "tex"},
+		{format: "tiff"},
+		{format: "tif"},
+		{
+			format: "",
+			err:    fmt.Errorf("unsupported format: \"\""),
+		},
+		{
+			format: "abc",
+			err:    fmt.Errorf("unsupported format: \"abc\""),
+		},
+	} {
+		t.Run(test.format, func(t *testing.T) {
+			_, err := NewFormattedCanvas(10, 10, test.format)
+			switch {
+			case err != nil && test.err != nil:
+				if got, want := err.Error(), test.err.Error(); got != want {
+					t.Fatalf("invalid error.\ngot= %v\nwant=%v", got, want)
+				}
+			case err != nil && test.err == nil:
+				t.Fatalf("unexpected error: %+v", err)
+			case err == nil && test.err != nil:
+				t.Fatalf("expected an error (got=%v)", err)
+			case err == nil && test.err == nil:
+				// ok
+			}
+		})
 	}
 }

--- a/vg/draw/draw_test.go
+++ b/vg/draw/draw_test.go
@@ -151,8 +151,6 @@ func TestFormattedCanvas(t *testing.T) {
 				t.Fatalf("unexpected error: %+v", err)
 			case err == nil && test.err != nil:
 				t.Fatalf("expected an error (got=%v)", err)
-			case err == nil && test.err == nil:
-				// ok
 			}
 		})
 	}


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
