### PR TITLE
plot: update Plot.WriterTo documentation

### DIFF
--- a/plot.go
+++ b/plot.go
@@ -439,7 +439,7 @@ func (p *Plot) NominalY(names ...string) {
 //
 // Supported formats are:
 //
-//  eps, jpg|jpeg, pdf, png, svg, and tif|tiff.
+//  eps, jpg|jpeg, pdf, png, svg, tex and tif|tiff.
 func (p *Plot) WriterTo(w, h vg.Length, format string) (io.WriterTo, error) {
 	c, err := draw.NewFormattedCanvas(w, h, format)
 	if err != nil {
@@ -454,7 +454,7 @@ func (p *Plot) WriterTo(w, h vg.Length, format string) (io.WriterTo, error) {
 //
 // Supported extensions are:
 //
-//  .eps, .jpg, .jpeg, .pdf, .png, .svg, .tif and .tiff.
+//  .eps, .jpg, .jpeg, .pdf, .png, .svg, .tex, .tif and .tiff.
 func (p *Plot) Save(w, h vg.Length, file string) (err error) {
 	f, err := os.Create(file)
 	if err != nil {


### PR DESCRIPTION
gonum/plot#587 updated vg/draw.NewFormattedCanvas to handle .tex files,
but we didn't update the documentation of plot.Plot.{Save,WriterTo}

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
