### PR TITLE
vg/vggio: use layout.Context as hook into Gio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module gonum.org/v1/plot
 go 1.13
 
 require (
-	gioui.org v0.0.0-20200618124658-602d54dc5ef7
+	gioui.org v0.0.0-20200628203458-851255f7a67b
 	github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af
 	github.com/fogleman/gg v1.3.0
 	github.com/go-latex/latex v0.0.0-20200518072620-0806b477ea35

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20200618124658-602d54dc5ef7 h1:PH02mpvkp5MNZcqi/wWY+YJTG5kvvuyc6kJ/efTGfXE=
 gioui.org v0.0.0-20200618124658-602d54dc5ef7/go.mod h1:jiUwifN9cRl/zmco43aAqh0aV+s9GbhG13KcD+gEpkU=
+gioui.org v0.0.0-20200628203458-851255f7a67b h1:2Eb0izWETwD/QZKFwDyyiUlV9cjFXg6Dl/fMfG7EPWU=
+gioui.org v0.0.0-20200628203458-851255f7a67b/go.mod h1:jiUwifN9cRl/zmco43aAqh0aV+s9GbhG13KcD+gEpkU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af h1:wVe6/Ea46ZMeNkQjjBW6xcqyQA/j5e0D6GytH95g0gQ=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/vg/vggio/example_vg_test.go
+++ b/vg/vggio/example_vg_test.go
@@ -12,6 +12,8 @@ import (
 	"gioui.org/app"
 	"gioui.org/io/key"
 	"gioui.org/io/system"
+	"gioui.org/layout"
+	"gioui.org/op"
 	"gioui.org/unit"
 
 	"gonum.org/v1/plot"
@@ -52,9 +54,13 @@ func ExampleCanvas() {
 					p.X.Label.Text = "X"
 					p.Y.Label.Text = "Y"
 
-					cnv := vggio.New(e, w, h, vggio.UseDPI(dpi))
+					gtx := layout.NewContext(new(op.Ops), e)
+					cnv := vggio.New(gtx, w, h, vggio.UseDPI(dpi))
 					p.Draw(draw.New(cnv))
 					cnv.Paint(e)
+
+				case system.DestroyEvent:
+					os.Exit(0)
 
 				case key.Event:
 					switch e.Name {

--- a/vg/vggio/vg.go
+++ b/vg/vggio/vg.go
@@ -11,7 +11,6 @@ import (
 	"gioui.org/f32"
 	"gioui.org/io/system"
 	"gioui.org/layout"
-	"gioui.org/op"
 	"gioui.org/op/paint"
 
 	"gonum.org/v1/plot/vg"
@@ -33,7 +32,7 @@ const DefaultDPI = 96
 // New returns a new image canvas with the provided dimensions and options.
 // The currently accepted options are UseDPI and UseBackgroundColor.
 // If the resolution or background color are not specified, defaults are used.
-func New(e system.FrameEvent, w, h vg.Length, opts ...option) *Canvas {
+func New(gtx layout.Context, w, h vg.Length, opts ...option) *Canvas {
 	cfg := &config{
 		dpi: DefaultDPI,
 		bkg: color.White,
@@ -42,7 +41,7 @@ func New(e system.FrameEvent, w, h vg.Length, opts ...option) *Canvas {
 		opt(cfg)
 	}
 	c := &Canvas{
-		gtx: layout.NewContext(new(op.Ops), e),
+		gtx: gtx,
 		Canvas: vgimg.NewWith(
 			vgimg.UseDPI(cfg.dpi),
 			vgimg.UseWH(w, h),


### PR DESCRIPTION
Use `layout.Context` instead of `system.FrameEvent` as the former is what we really use, and is "more general" than the latter.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
