### PR TITLE
Changes PDF handling to use supported libraries.

### DIFF
--- a/cmpimg/cmpimg.go
+++ b/cmpimg/cmpimg.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"strings"
 
-	"rsc.io/pdf"
+	"github.com/phpdave11/gofpdf"
 
 	_ "image/jpeg"
 	_ "image/png"
@@ -50,19 +50,7 @@ func Equal(typ string, raw1, raw2 []byte) (bool, error) {
 		return true, nil
 
 	case "pdf":
-		r1 := bytes.NewReader(raw1)
-		pdf1, err := pdf.NewReader(r1, r1.Size())
-		if err != nil {
-			return false, err
-		}
-
-		r2 := bytes.NewReader(raw2)
-		pdf2, err := pdf.NewReader(r2, r2.Size())
-		if err != nil {
-			return false, err
-		}
-
-		return cmpPdf(pdf1, pdf2), nil
+		return cmpPdf(raw1, raw2), nil
 
 	case "jpeg", "jpg", "png", "tiff":
 		v1, _, err := image.Decode(bytes.NewReader(raw1))
@@ -80,24 +68,8 @@ func Equal(typ string, raw1, raw2 []byte) (bool, error) {
 	}
 }
 
-func cmpPdf(pdf1, pdf2 *pdf.Reader) bool {
-	n1 := pdf1.NumPage()
-	n2 := pdf2.NumPage()
-	if n1 != n2 {
-		return false
-	}
-
-	for i := 1; i <= n1; i++ {
-		p1 := pdf1.Page(i).Content()
-		p2 := pdf2.Page(i).Content()
-		if !reflect.DeepEqual(p1, p2) {
-			return false
-		}
-	}
-
-	t1 := pdf1.Trailer().String()
-	t2 := pdf2.Trailer().String()
-	return t1 == t2
+func cmpPdf(pdf1, pdf2 []byte) bool {
+	return gofpdf.CompareBytes(pdf1, pdf1, false) == nil
 }
 
 // Diff calculates an intensity-scaled difference between images a and b

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,8 @@ require (
 	github.com/fogleman/gg v1.3.0
 	github.com/go-latex/latex v0.0.0-20200518072620-0806b477ea35
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	github.com/jung-kurt/gofpdf v1.16.2
+	github.com/phpdave11/gofpdf v1.4.2
 	golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3
-	golang.org/x/image v0.0.0-20200618115811-c13761719519
+	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
 	gonum.org/v1/gonum v0.8.2
-	rsc.io/pdf v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,12 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5PtRc=
 github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
+github.com/phpdave11/gofpdf v1.4.2 h1:KPKiIbfwbvC/wOncwhrpRdXVj2CZTCFlw4wnoyjtHfQ=
+github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -40,6 +44,8 @@ golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a/go.mod h1:FeLwcggjj3mMvU+o
 golang.org/x/image v0.0.0-20200430140353-33d19683fad8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20200618115811-c13761719519 h1:1e2ufUJNM3lCHEY5jIgac/7UTjd6cgJNdatjPdFWf34=
 golang.org/x/image v0.0.0-20200618115811-c13761719519/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 h1:QelT11PB4FXiDEXucrfNckHoFxwt8USGY1ajP1ZF5lM=
+golang.org/x/image v0.0.0-20200927104501-e162460cd6b5/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/vg/vgpdf/vgpdf.go
+++ b/vg/vgpdf/vgpdf.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package vgpdf implements the vg.Canvas interface
-// using gofpdf (github.com/jung-kurt/gofpdf).
+// using gofpdf (github.com/phpdave11/gofpdf).
 package vgpdf // import "gonum.org/v1/plot/vg/vgpdf"
 
 import (
@@ -20,7 +20,7 @@ import (
 	"os"
 	"path/filepath"
 
-	pdf "github.com/jung-kurt/gofpdf"
+	pdf "github.com/phpdave11/gofpdf"
 
 	"gonum.org/v1/plot/vg"
 	"gonum.org/v1/plot/vg/fonts"


### PR DESCRIPTION
The existing PDF functionality was based on two now-unsupported libraries:
rsc.io/pdf and github.com/jung-kurt/gofpdf

This change drops the rsc.io/pdf dependency, and moves the jung-kurt one to
a now maintained fork: github.com/phpdave11/gofpdf

I also had to replace the custom pdf comparison function (built on rsc.io/pdf)
with an existing comparison method in gofpdf. There weren't any tests here, so
I'm not sure how to be super confident the results will be the same.

Please take a look.


