### PR TITLE
all: define vg.FontExtents.Descent as a positive value to follow x/image/font/sfnt convention

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -230,7 +230,7 @@ type horizontalAxis struct {
 // size returns the height of the axis.
 func (a horizontalAxis) size() (h vg.Length) {
 	if a.Label.Text != "" { // We assume that the label isn't rotated.
-		h -= a.Label.Font.Extents().Descent
+		h += a.Label.Font.Extents().Descent
 		h += a.Label.Height(a.Label.Text)
 		h += a.Label.Padding
 	}
@@ -263,7 +263,7 @@ func (a horizontalAxis) draw(c draw.Canvas) {
 	}
 	if a.Label.Text != "" {
 		descent := a.Label.Font.Extents().Descent
-		c.FillText(a.Label.TextStyle, vg.Point{X: x, Y: y - descent}, a.Label.Text)
+		c.FillText(a.Label.TextStyle, vg.Point{X: x, Y: y + descent}, a.Label.Text)
 		y += a.Label.Height(a.Label.Text)
 		y += a.Label.Padding
 	}
@@ -276,7 +276,7 @@ func (a horizontalAxis) draw(c draw.Canvas) {
 		if !c.ContainsX(x) || t.IsMinor() {
 			continue
 		}
-		c.FillText(a.Tick.Label, vg.Point{X: x, Y: y + ticklabelheight - descent}, t.Label)
+		c.FillText(a.Tick.Label, vg.Point{X: x, Y: y + ticklabelheight + descent}, t.Label)
 	}
 
 	if len(marks) > 0 {
@@ -325,7 +325,7 @@ type verticalAxis struct {
 // size returns the width of the axis.
 func (a verticalAxis) size() (w vg.Length) {
 	if a.Label.Text != "" { // We assume that the label isn't rotated.
-		w -= a.Label.Font.Extents().Descent
+		w += a.Label.Font.Extents().Descent
 		w += a.Label.Height(a.Label.Text)
 		w += a.Label.Padding
 	}
@@ -364,8 +364,8 @@ func (a verticalAxis) draw(c draw.Canvas) {
 			y -= a.Label.Font.Width(a.Label.Text) / 2
 		}
 		descent := a.Label.Font.Extents().Descent
-		c.FillText(sty, vg.Point{X: x + descent, Y: y}, a.Label.Text)
-		x -= descent
+		c.FillText(sty, vg.Point{X: x - descent, Y: y}, a.Label.Text)
+		x += descent
 		x += a.Label.Padding
 	}
 	marks := a.Tick.Marker.Ticks(a.Min, a.Max)
@@ -380,7 +380,7 @@ func (a verticalAxis) draw(c draw.Canvas) {
 		if !c.ContainsY(y) || t.IsMinor() {
 			continue
 		}
-		c.FillText(a.Tick.Label, vg.Point{X: x, Y: y - descent}, t.Label)
+		c.FillText(a.Tick.Label, vg.Point{X: x, Y: y + descent}, t.Label)
 		major = true
 	}
 	if major {

--- a/legend.go
+++ b/legend.go
@@ -125,13 +125,13 @@ func (l *Legend) Draw(c draw.Canvas) {
 		panic("plot: invalid vertical offset for the legend's entries")
 	}
 	yoff := vg.Length(l.YPosition-draw.PosBottom) / 2
-	yoff -= descent
+	yoff += descent
 
 	for _, e := range l.entries {
 		for _, t := range e.thumbs {
 			t.Thumbnail(icon)
 		}
-		yoffs := (enth + descent - sty.Rectangle(e.text).Max.Y) / 2
+		yoffs := (enth - descent - sty.Rectangle(e.text).Max.Y) / 2
 		yoffs += yoff
 		c.FillText(sty, vg.Point{X: textx, Y: icon.Min.Y + yoffs}, e.text)
 		icon.Min.Y -= enth + l.Padding

--- a/plot.go
+++ b/plot.go
@@ -153,7 +153,7 @@ func (p *Plot) Draw(c draw.Canvas) {
 	}
 	if p.Title.Text != "" {
 		descent := p.Title.TextStyle.Font.Extents().Descent
-		c.FillText(p.Title.TextStyle, vg.Point{X: c.Center().X, Y: c.Max.Y - descent}, p.Title.Text)
+		c.FillText(p.Title.TextStyle, vg.Point{X: c.Center().X, Y: c.Max.Y + descent}, p.Title.Text)
 		_, h, d := p.Title.Handler.Box(p.Title.Text, p.Title.Font)
 		c.Max.Y -= h + d
 		c.Max.Y -= p.Title.Padding
@@ -183,7 +183,7 @@ func (p *Plot) Draw(c draw.Canvas) {
 // the plot data will be drawn.
 func (p *Plot) DataCanvas(da draw.Canvas) draw.Canvas {
 	if p.Title.Text != "" {
-		da.Max.Y -= p.Title.Height(p.Title.Text) - p.Title.Font.Extents().Descent
+		da.Max.Y -= p.Title.Height(p.Title.Text) + p.Title.Font.Extents().Descent
 		da.Max.Y -= p.Title.Padding
 	}
 	p.X.sanitizeRange()

--- a/vg/draw/text.go
+++ b/vg/draw/text.go
@@ -75,9 +75,9 @@ func (sty TextStyle) Height(txt string) vg.Length {
 	}
 	var (
 		e       = sty.Font.Extents()
-		linegap = (e.Height - e.Ascent + e.Descent) * vg.Length(nl-1)
+		linegap = (e.Height - e.Ascent - e.Descent) * vg.Length(nl-1)
 	)
-	return (e.Ascent-e.Descent)*vg.Length(nl) + linegap
+	return (e.Ascent+e.Descent)*vg.Length(nl) + linegap
 }
 
 // Rectangle returns a rectangle giving the bounds of

--- a/vg/draw/text_plain.go
+++ b/vg/draw/text_plain.go
@@ -24,7 +24,7 @@ func (hdlr PlainTextHandler) Box(txt string, fnt vg.Font) (width, height, depth 
 	nl := hdlr.textNLines(txt)
 	if nl != 0 {
 		height = ext.Height*vg.Length(nl-1) + ext.Ascent
-		depth = -ext.Descent
+		depth = ext.Descent
 	}
 
 	for _, line := range strings.Split(strings.TrimRight(txt, "\n"), "\n") {

--- a/vg/font.go
+++ b/vg/font.go
@@ -149,7 +149,7 @@ type FontExtents struct {
 
 	// Descent is the distance that the text
 	// extends below the baseline.  The descent
-	// is given as a negative value.
+	// is given as a positive value.
 	Descent Length
 
 	// Height is the distance from the lowest
@@ -173,7 +173,7 @@ func (f *Font) Extents() FontExtents {
 	scale := f.Size / Points(float64(ppem))
 	return FontExtents{
 		Ascent:  Points(float64(met.Ascent)) * scale,
-		Descent: Points(float64(-met.Descent)) * scale, // sfnt-descent is >0
+		Descent: Points(float64(met.Descent)) * scale,
 		Height:  Points(float64(met.Height)) * scale,
 	}
 }

--- a/vg/font_test.go
+++ b/vg/font_test.go
@@ -25,17 +25,17 @@ func TestFontExtends(t *testing.T) {
 			want: map[Length]FontExtents{
 				10: FontExtents{
 					Ascent:  8.9111328125,
-					Descent: -2.1630859375,
+					Descent: 2.1630859375,
 					Height:  11.4990234375,
 				},
 				12: FontExtents{
 					Ascent:  10.693359375,
-					Descent: -2.595703125,
+					Descent: 2.595703125,
 					Height:  13.798828125,
 				},
 				24: FontExtents{
 					Ascent:  21.38671875,
-					Descent: -5.19140625,
+					Descent: 5.19140625,
 					Height:  27.59765625,
 				},
 			},
@@ -45,17 +45,17 @@ func TestFontExtends(t *testing.T) {
 			want: map[Length]FontExtents{
 				10: FontExtents{
 					Ascent:  8.9111328125,
-					Descent: -2.1630859375,
+					Descent: 2.1630859375,
 					Height:  11.4990234375,
 				},
 				12: FontExtents{
 					Ascent:  10.693359375,
-					Descent: -2.595703125,
+					Descent: 2.595703125,
 					Height:  13.798828125,
 				},
 				24: FontExtents{
 					Ascent:  21.38671875,
-					Descent: -5.19140625,
+					Descent: 5.19140625,
 					Height:  27.59765625,
 				},
 			},
@@ -65,17 +65,17 @@ func TestFontExtends(t *testing.T) {
 			want: map[Length]FontExtents{
 				10: FontExtents{
 					Ascent:  8.9111328125,
-					Descent: -2.1630859375,
+					Descent: 2.1630859375,
 					Height:  11.4990234375,
 				},
 				12: FontExtents{
 					Ascent:  10.693359375,
-					Descent: -2.595703125,
+					Descent: 2.595703125,
 					Height:  13.798828125,
 				},
 				24: FontExtents{
 					Ascent:  21.38671875,
-					Descent: -5.19140625,
+					Descent: 5.19140625,
 					Height:  27.59765625,
 				},
 			},
@@ -85,17 +85,17 @@ func TestFontExtends(t *testing.T) {
 			want: map[Length]FontExtents{
 				10: FontExtents{
 					Ascent:  8.9111328125,
-					Descent: -2.1630859375,
+					Descent: 2.1630859375,
 					Height:  11.4990234375,
 				},
 				12: FontExtents{
 					Ascent:  10.693359375,
-					Descent: -2.595703125,
+					Descent: 2.595703125,
 					Height:  13.798828125,
 				},
 				24: FontExtents{
 					Ascent:  21.38671875,
-					Descent: -5.19140625,
+					Descent: 5.19140625,
 					Height:  27.59765625,
 				},
 			},

--- a/vg/vggio/vggio.go
+++ b/vg/vggio/vggio.go
@@ -321,7 +321,7 @@ func (c *Canvas) FillString(font vg.Font, pt vg.Point, txt string) {
 
 	e := font.Extents()
 	x := pt.X.Dots(c.ctx.dpi)
-	y := pt.Y.Dots(c.ctx.dpi) + e.Descent.Dots(c.ctx.dpi)
+	y := pt.Y.Dots(c.ctx.dpi) - e.Descent.Dots(c.ctx.dpi)
 	h := c.ctx.h.Dots(c.ctx.dpi)
 
 	c.ctx.invertY()


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
