### PR TITLE
travis: set up xvfb for vggio tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: true
 
+dist: bionic
+
 language: go
 go_import_path: gonum.org/v1/plot
 
@@ -17,9 +19,14 @@ env:
   global:
    - GO111MODULE: "on"
    - EGL_PLATFORM: "x11"
+   - DISPLAY: ":99"
 
 # Get coverage tools, and start the virtual framebuffer.
 before_install:
+ - sudo apt-get update
+ - sudo apt-get install -qq pkg-config libwayland-dev libx11-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libgles2-mesa-dev libegl1-mesa-dev libffi-dev libxcursor-dev xvfb xdotool
+ - Xvfb :99 -screen 0 1920x1024x24 &
+
  # Required for format check.
  - go get golang.org/x/tools/cmd/goimports
  # Required for imports check.
@@ -29,9 +36,6 @@ before_install:
  # Required for coverage.
  - go get golang.org/x/tools/cmd/cover
  - go get github.com/mattn/goveralls
-
-before_script:
- - sudo apt-get install -qq pkg-config libwayland-dev libx11-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libgles2-mesa-dev libegl1-mesa-dev libffi-dev libxcursor-dev
 
 # Get deps, build, test, and ensure the code is gofmt'ed.
 # If we are building as gonum, then we have access to the coveralls api key, so we can run coverage as well.


### PR DESCRIPTION
Please take a look.

This mostly fixes the travis build, but it still fails with
```
=== RUN   TestCanvas
    vggio_test.go:84: could not create screenshot: vggio: could not create headless window: eglInitialize failed: 0x3001
--- FAIL: TestCanvas (0.02s)
=== RUN   TestCollectionName
--- PASS: TestCollectionName (0.00s)
=== RUN   TestLabels
    vggio_test.go:244: could not create screenshot: vggio: could not create headless window: eglInitialize failed: 0x3001
--- FAIL: TestLabels (0.00s)
FAIL
FAIL	gonum.org/v1/plot/vg/vggio	0.133s
```
Any suggestions?

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
