### PR TITLE
palette: use strconv.Atoi instead of fmt.Sprintf

### DIFF
--- a/palette/reverse_example_test.go
+++ b/palette/reverse_example_test.go
@@ -5,8 +5,8 @@
 package palette_test
 
 import (
-	"fmt"
 	"log"
+	"strconv"
 
 	"gonum.org/v1/plot"
 	"gonum.org/v1/plot/palette"
@@ -40,7 +40,7 @@ func ExampleReverse_palette() {
 	p := plot.New()
 	thumbs := plotter.PaletteThumbnailers(palette.Reverse(moreland.Kindlmann()).Palette(10))
 	for i, t := range thumbs {
-		p.Legend.Add(fmt.Sprint(i), t)
+		p.Legend.Add(strconv.Itoa(i), t)
 	}
 	p.HideAxes()
 	p.X.Padding = 0


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
