### PR TITLE
ci: make cache works by removing comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,13 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.GOPATH }}/src/gonum.org/v1/plot
+
     - name: Cache-Go
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         # In order:
         # * Module download cache
@@ -41,15 +46,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             '%LocalAppData%\go-build'
-
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-          path: ${{ env.GOPATH }}/src/gonum.org/v1/plot
 
     - name: Install Linux packages
       if: matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,16 @@ jobs:
     - name: Cache-Go
       uses: actions/cache@v1
       with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
         path: |
-            ~/go/pkg/mod              # Module download cache
-            ~/.cache/go-build         # Build cache (Linux)
-            ~/Library/Caches/go-build # Build cache (Mac)
-            '%LocalAppData%\go-build' # Build cache (Windows)
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            '%LocalAppData%\go-build'
 
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,8 +30,13 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.GOPATH }}/src/gonum.org/v1/plot
+
     - name: Cache-Go
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         # In order:
         # * Module download cache
@@ -43,15 +48,9 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
             '%LocalAppData%\go-build'
-
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-          path: ${{ env.GOPATH }}/src/gonum.org/v1/plot
 
     - name: Coverage
       if: matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,11 +33,16 @@ jobs:
     - name: Cache-Go
       uses: actions/cache@v1
       with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
         path: |
-            ~/go/pkg/mod              # Module download cache
-            ~/.cache/go-build         # Build cache (Linux)
-            ~/Library/Caches/go-build # Build cache (Mac)
-            '%LocalAppData%\go-build' # Build cache (Windows)
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            '%LocalAppData%\go-build'
 
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |


### PR DESCRIPTION
The path is a multiline string, which includes comments in its value. This
means that the caching was not working at all, because it would include
the comment in the path. Here I'm moving the comments, which fixes the
caching so it works.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
