### PR TITLE
Fix off by one indexing bug in plotutil.MedianAndMinMax

### DIFF
--- a/plotutil/errorpoints.go
+++ b/plotutil/errorpoints.go
@@ -103,7 +103,7 @@ func MedianAndMinMax(vls []float64) (med, lowerr, higherr float64) {
 	}
 	sort.Float64s(vls)
 	if n%2 == 0 {
-		med = (vls[n/2+1]-vls[n/2])/2 + vls[n/2]
+		med = (vls[n/2]-vls[n/2-1])/2 + vls[n/2-1]
 	} else {
 		med = vls[n/2]
 	}


### PR DESCRIPTION
Fix off by one indexing bug in plotutil.MedianAndMinMax when determining the mean of the two inner-most elements in the slice.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
