### PR TITLE
all: use built-in min and max functions

### DIFF
--- a/axis.go
+++ b/axis.go
@@ -490,14 +490,14 @@ type DefaultTicks struct{}
 var _ Ticker = DefaultTicks{}
 
 // Ticks returns Ticks in the specified range.
-func (DefaultTicks) Ticks(minTick, maxTick float64) []Tick {
-	if maxTick <= minTick {
+func (DefaultTicks) Ticks(min, max float64) []Tick {
+	if max <= min {
 		panic("illegal range")
 	}
 
 	const suggestedTicks = 3
 
-	labels, step, q, mag := talbotLinHanrahan(minTick, maxTick, suggestedTicks, withinData, nil, nil, nil)
+	labels, step, q, mag := talbotLinHanrahan(min, max, suggestedTicks, withinData, nil, nil, nil)
 	majorDelta := step * math.Pow10(mag)
 	if q == 0 {
 		// Simple fall back was chosen, so
@@ -516,7 +516,7 @@ func (DefaultTicks) Ticks(minTick, maxTick float64) []Tick {
 	if math.Trunc(q) != q {
 		off += 2
 	}
-	prec := min(6, max(off, -mag))
+	prec := minInt(6, maxInt(off, -mag))
 	ticks := make([]Tick, len(labels))
 	for i, v := range labels {
 		ticks[i] = Tick{Value: v, Label: strconv.FormatFloat(v, fc, prec, 64)}
@@ -539,7 +539,7 @@ func (DefaultTicks) Ticks(minTick, maxTick float64) []Tick {
 	// Find the first minor tick not greater
 	// than the lowest data value.
 	var i float64
-	for labels[0]+(i-1)*minorDelta > minTick {
+	for labels[0]+(i-1)*minorDelta > min {
 		i--
 	}
 	// Add ticks at minorDelta intervals when
@@ -547,7 +547,7 @@ func (DefaultTicks) Ticks(minTick, maxTick float64) []Tick {
 	// labelled tick.
 	for {
 		val := labels[0] + i*minorDelta
-		if val > maxTick {
+		if val > max {
 			break
 		}
 		found := false
@@ -563,6 +563,14 @@ func (DefaultTicks) Ticks(minTick, maxTick float64) []Tick {
 	}
 
 	return ticks
+}
+
+func minInt(a, b int) int {
+	return min(a, b)
+}
+
+func maxInt(a, b int) int {
+	return max(a, b)
 }
 
 // LogTicks is suitable for the Tick.Marker field of an Axis,

--- a/axis.go
+++ b/axis.go
@@ -490,14 +490,14 @@ type DefaultTicks struct{}
 var _ Ticker = DefaultTicks{}
 
 // Ticks returns Ticks in the specified range.
-func (DefaultTicks) Ticks(min, max float64) []Tick {
-	if max <= min {
+func (DefaultTicks) Ticks(minTick, maxTick float64) []Tick {
+	if maxTick <= minTick {
 		panic("illegal range")
 	}
 
 	const suggestedTicks = 3
 
-	labels, step, q, mag := talbotLinHanrahan(min, max, suggestedTicks, withinData, nil, nil, nil)
+	labels, step, q, mag := talbotLinHanrahan(minTick, maxTick, suggestedTicks, withinData, nil, nil, nil)
 	majorDelta := step * math.Pow10(mag)
 	if q == 0 {
 		// Simple fall back was chosen, so
@@ -516,7 +516,7 @@ func (DefaultTicks) Ticks(min, max float64) []Tick {
 	if math.Trunc(q) != q {
 		off += 2
 	}
-	prec := minInt(6, maxInt(off, -mag))
+	prec := min(6, max(off, -mag))
 	ticks := make([]Tick, len(labels))
 	for i, v := range labels {
 		ticks[i] = Tick{Value: v, Label: strconv.FormatFloat(v, fc, prec, 64)}
@@ -539,7 +539,7 @@ func (DefaultTicks) Ticks(min, max float64) []Tick {
 	// Find the first minor tick not greater
 	// than the lowest data value.
 	var i float64
-	for labels[0]+(i-1)*minorDelta > min {
+	for labels[0]+(i-1)*minorDelta > minTick {
 		i--
 	}
 	// Add ticks at minorDelta intervals when
@@ -547,7 +547,7 @@ func (DefaultTicks) Ticks(min, max float64) []Tick {
 	// labelled tick.
 	for {
 		val := labels[0] + i*minorDelta
-		if val > max {
+		if val > maxTick {
 			break
 		}
 		found := false
@@ -563,20 +563,6 @@ func (DefaultTicks) Ticks(min, max float64) []Tick {
 	}
 
 	return ticks
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // LogTicks is suitable for the Tick.Marker field of an Axis,

--- a/plotter/image.go
+++ b/plotter/image.go
@@ -91,13 +91,13 @@ func (img *Image) transformFor(p *plot.Plot) image.Image {
 		cTrans := int(p.X.Norm(img.x(c)) * float64(img.cols))
 		// Find the equivalent column of the previous image column after applying
 		// axis transforms.
-		cPrevTrans := int(p.X.Norm(img.x(maxInt(c-1, 0))) * float64(img.cols))
+		cPrevTrans := int(p.X.Norm(img.x(max(c-1, 0))) * float64(img.cols))
 		for r := range img.rows {
 			// Find the equivalent image row after applying axis transforms.
 			rTrans := int(p.Y.Norm(img.y(r)) * float64(img.rows))
 			// Find the equivalent row of the previous image row after applying
 			// axis transforms.
-			rPrevTrans := int(p.Y.Norm(img.y(maxInt(r-1, 0))) * float64(img.rows))
+			rPrevTrans := int(p.Y.Norm(img.y(max(r-1, 0))) * float64(img.rows))
 			crColor := img.img.At(c, img.rows-r-1)
 			// Set all the pixels in the new image between (cPrevTrans, rPrevTrans)
 			// and (cTrans, rTrans) to the color at (c,r) in the original image.
@@ -110,13 +110,6 @@ func (img *Image) transformFor(p *plot.Plot) image.Image {
 		}
 	}
 	return o
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func (img *Image) x(c int) float64 {

--- a/plotter/johnson.go
+++ b/plotter/johnson.go
@@ -114,13 +114,6 @@ func (j *johnson) unblock(u int) {
 	}
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // tarjan implements Tarjan's strongly connected component finding
 // algorithm. The implementation is from the pseudocode at
 //

--- a/vg/vgimg/vgimg_test.go
+++ b/vg/vgimg/vgimg_test.go
@@ -150,13 +150,6 @@ func TestIssue540(t *testing.T) {
 }
 
 func TestIssue687(t *testing.T) {
-	min := func(a, b int) int {
-		if a < b {
-			return a
-		}
-		return b
-	}
-
 	const (
 		fname = "testdata/issue687.png"
 		size  = 500


### PR DESCRIPTION
We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
