### PR TITLE
palette/moreland: fix floating-point arithmetic error in Palette

### DIFF
--- a/palette/moreland/luminance.go
+++ b/palette/moreland/luminance.go
@@ -176,9 +176,16 @@ func (l luminance) Palette(n int) palette.Palette {
 		l.SetMax(1)
 	}
 	delta := (l.max - l.min) / float64(n-1)
+	var v float64
 	c := make([]color.Color, n)
 	for i := range n {
-		v := min(l.min+float64(delta*float64(i)), l.max)
+		if i == n-1 {
+			// Avoid potential overflow on last element
+			// due to floating point error.
+			v = l.max
+		} else {
+			v = l.min + float64(delta*float64(i))
+		}
 		var err error
 		c[i], err = l.At(v)
 		if err != nil {

--- a/palette/moreland/luminance.go
+++ b/palette/moreland/luminance.go
@@ -176,10 +176,9 @@ func (l luminance) Palette(n int) palette.Palette {
 		l.SetMax(1)
 	}
 	delta := (l.max - l.min) / float64(n-1)
-	var v float64
 	c := make([]color.Color, n)
 	for i := range n {
-		v = l.min + float64(delta*float64(i))
+		v := min(l.min+float64(delta*float64(i)), l.max)
 		var err error
 		c[i], err = l.At(v)
 		if err != nil {

--- a/palette/moreland/luminance_test.go
+++ b/palette/moreland/luminance_test.go
@@ -162,7 +162,7 @@ func BenchmarkLuminance_At(b *testing.B) {
 	}
 }
 
-func Test_luminance_Palette(t *testing.T) {
+func TestIssue798Kindlmann(t *testing.T) {
 	// https://github.com/gonum/plot/issues/798
 	colors := Kindlmann()
 	colors.SetMin(0.3402859786606234)

--- a/palette/moreland/luminance_test.go
+++ b/palette/moreland/luminance_test.go
@@ -161,3 +161,11 @@ func BenchmarkLuminance_At(b *testing.B) {
 		})
 	}
 }
+
+func Test_luminance_Palette(t *testing.T) {
+	// https://github.com/gonum/plot/issues/798
+	colors := Kindlmann()
+	colors.SetMin(0.3402859786606234)
+	colors.SetMax(15.322841335211892)
+	colors.Palette(15)
+}

--- a/palette/moreland/luminance_test.go
+++ b/palette/moreland/luminance_test.go
@@ -162,10 +162,46 @@ func BenchmarkLuminance_At(b *testing.B) {
 	}
 }
 
+// See https://github.com/gonum/plot/issues/798
 func TestIssue798Kindlmann(t *testing.T) {
-	// https://github.com/gonum/plot/issues/798
-	colors := Kindlmann()
-	colors.SetMin(0.3402859786606234)
-	colors.SetMax(15.322841335211892)
-	colors.Palette(15)
+	for _, test := range []struct {
+		n        int
+		min, max float64
+	}{
+		0: {n: 2, min: 0, max: 1},
+		1: {n: 15, min: 0.3402859786606234, max: 15.322841335211892},
+	} {
+		t.Run("", func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r != nil {
+					t.Errorf("unexpected panic with n=%d min=%f max=%f: %v", test.n, test.min, test.max, r)
+				}
+			}()
+			colors := Kindlmann()
+			colors.SetMin(test.min)
+			colors.SetMax(test.max)
+			col := colors.Palette(test.n).Colors()
+			min, err := colors.At(test.min)
+			if err != nil {
+				t.Fatalf("unexpected error calling colors.At(min): %v", err)
+			}
+			if !sameColor(min, col[0]) {
+				t.Errorf("unexpected min color %#v != %#v", min, col[0])
+			}
+			max, err := colors.At(test.max)
+			if err != nil {
+				t.Fatalf("unexpected error calling colors.At(max): %v", err)
+			}
+			if !sameColor(max, col[len(col)-1]) {
+				t.Errorf("unexpected max color %#v != %#v", max, col[len(col)-1])
+			}
+		})
+	}
+}
+
+func sameColor(a, b color.Color) bool {
+	ar, ag, ab, aa := a.RGBA()
+	br, bg, bb, ba := b.RGBA()
+	return ar == br && ag == bg && ab == bb && aa == ba
 }

--- a/palette/moreland/smooth.go
+++ b/palette/moreland/smooth.go
@@ -171,9 +171,16 @@ func (p smoothDiverging) Palette(n int) palette.Palette {
 		p.SetMax(1)
 	}
 	delta := (p.max - p.min) / float64(n-1)
+	var v float64
 	c := make([]color.Color, n)
 	for i := range c {
-		v := min(p.min+float64(delta*float64(i)), p.max)
+		if i == n-1 {
+			// Avoid potential overflow on last element
+			// due to floating point error.
+			v = p.max
+		} else {
+			v = p.min + float64(delta*float64(i))
+		}
 		var err error
 		c[i], err = p.At(v)
 		if err != nil {

--- a/palette/moreland/smooth.go
+++ b/palette/moreland/smooth.go
@@ -173,7 +173,7 @@ func (p smoothDiverging) Palette(n int) palette.Palette {
 	delta := (p.max - p.min) / float64(n-1)
 	c := make([]color.Color, n)
 	for i := range c {
-		v := p.min + float64(delta*float64(i))
+		v := min(p.min+float64(delta*float64(i)), p.max)
 		var err error
 		c[i], err = p.At(v)
 		if err != nil {

--- a/palette/moreland/smooth_test.go
+++ b/palette/moreland/smooth_test.go
@@ -246,3 +246,11 @@ func similar(a, b color.Color, tolerance float64) bool {
 	}
 	return true
 }
+
+func Test_smoothDiverging_Palette(t *testing.T) {
+	// https://github.com/gonum/plot/issues/798
+	colors := SmoothBlueRed()
+	colors.SetMin(0.3402859786606234)
+	colors.SetMax(15.322841335211892)
+	colors.Palette(15)
+}

--- a/palette/moreland/smooth_test.go
+++ b/palette/moreland/smooth_test.go
@@ -247,7 +247,7 @@ func similar(a, b color.Color, tolerance float64) bool {
 	return true
 }
 
-func Test_smoothDiverging_Palette(t *testing.T) {
+func TestIssue798SmoothBlueRed(t *testing.T) {
 	// https://github.com/gonum/plot/issues/798
 	colors := SmoothBlueRed()
 	colors.SetMin(0.3402859786606234)

--- a/palette/moreland/smooth_test.go
+++ b/palette/moreland/smooth_test.go
@@ -247,10 +247,40 @@ func similar(a, b color.Color, tolerance float64) bool {
 	return true
 }
 
+// See https://github.com/gonum/plot/issues/798
 func TestIssue798SmoothBlueRed(t *testing.T) {
-	// https://github.com/gonum/plot/issues/798
-	colors := SmoothBlueRed()
-	colors.SetMin(0.3402859786606234)
-	colors.SetMax(15.322841335211892)
-	colors.Palette(15)
+	for _, test := range []struct {
+		n        int
+		min, max float64
+	}{
+		0: {n: 2, min: 0, max: 1},
+		1: {n: 15, min: 0.3402859786606234, max: 15.322841335211892},
+	} {
+		t.Run("", func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r != nil {
+					t.Errorf("unexpected panic with n=%d min=%f max=%f: %v", test.n, test.min, test.max, r)
+				}
+			}()
+			colors := SmoothBlueRed()
+			colors.SetMin(test.min)
+			colors.SetMax(test.max)
+			col := colors.Palette(test.n).Colors()
+			min, err := colors.At(test.min)
+			if err != nil {
+				t.Fatalf("unexpected error calling colors.At(min): %v", err)
+			}
+			if !sameColor(min, col[0]) {
+				t.Errorf("unexpected min color %#v != %#v", min, col[0])
+			}
+			max, err := colors.At(test.max)
+			if err != nil {
+				t.Fatalf("unexpected error calling colors.At(max): %v", err)
+			}
+			if !sameColor(max, col[len(col)-1]) {
+				t.Errorf("unexpected max color %#v != %#v", max, col[len(col)-1])
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/gonum/plot/issues/798.

This PR fixes a panic in the `Palette` method caused by a floating-point precision error, where the computed value `v` slightly exceeds the upper bound `l.max`.


### Debugger screenshot

![2025-03-22_16-50](https://github.com/user-attachments/assets/8aadc59d-4df5-4043-a036-7bdc16fdb4ed)

### Problem

As shown in the above screenshot, we have the following values:

- `l.min = 0.3402859786606234`
- `l.max = 15.322841335211892`
- `n = 15`
- `delta = 1.0701825254679478`
- `i = 14`
- `v = 15.322841335211894` (note here `v` is `0.000000000000002` greater than `l.max`)

The expected calculation of `delta`:

```
delta = (l.max - l.min) / (n - 1)
      = (15.322841335211892 - 0.3402859786606234) / (15 - 1)
      = 1.0701825254679478
```

This confirms that `delta` is correct and has no floating-point error.


Next, the expected calculation of `v`:

```
v = l.min + (delta  * i)
  = 0.3402859786606234 + (1.0701825254679478 * 14)
  = 15.322841335211892
```

Ideally, `v` should be exactly equal to `l.max`. However, due to a small floating-point precision error of `0.000000000000002`, `v` becomes slightly greater than `l.max`, triggering the panic in `checkRange` function:

https://github.com/gonum/plot/blob/2815ea166a2a2c6b1f31037ebaa26616029a2929/palette/moreland/luminance.go#L116-L118

### Solution

Use the built-in `min` function to ensure `v` does not exceed `l.max`. If `v` becomes greater than `l.max` due to floating-point precision errors, it will be capped at `l.max`.